### PR TITLE
static-delta: fix "static-delta list"

### DIFF
--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -62,6 +62,7 @@ ostree --repo=repo static-delta list
 origrev=$(ostree --repo=repo rev-parse test^)
 newrev=$(ostree --repo=repo rev-parse test)
 ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev}
+ostree --repo=repo static-delta list | grep ${origrev} | grep ${newrev} || exit 1
 
 origstart=$(echo ${origrev} | dd bs=1 count=2 2>/dev/null)
 origend=$(echo ${origrev} | dd bs=1 skip=2 2>/dev/null)


### PR DESCRIPTION
The file "superblock" is contained under a second level hierarchy:

repo/deltas/$hash1[0-2]/$hash1[2-64]-$hash2[0-64]/superblock

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>