### PR TITLE
refs: Use G_IO_ERROR_NOT_FOUND when a ref lookup fails

### DIFF
--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -259,7 +259,7 @@ resolve_refspec_fallback (OstreeRepo     *self,
     }
   else if (!allow_noent)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
                    "Refspec '%s%s%s' not found",
                    remote ? remote : "",
                    remote ? ":" : "",


### PR DESCRIPTION
rpm-ostree had code to check for this, which didn't actually work.

I don't see a no backwards compatibility concern in changing this, as
it's unlikely a caller would try to sensibly disambiguate FAILED.