### PR TITLE
Pull metadata objects before content objects

### DIFF
--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -36,6 +36,9 @@ G_BEGIN_DECLS
 #define OSTREE_IS_FETCHER_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE ((k), OSTREE_TYPE_FETCHER))
 #define OSTREE_FETCHER_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS ((o), OSTREE_TYPE_FETCHER, OstreeFetcherClass))
 
+/* Lower values have higher priority */
+#define OSTREE_FETCHER_DEFAULT_PRIORITY 0
+
 typedef struct OstreeFetcherClass   OstreeFetcherClass;
 typedef struct OstreeFetcher   OstreeFetcher;
 
@@ -68,6 +71,7 @@ guint64 _ostree_fetcher_bytes_transferred (OstreeFetcher       *self);
 void _ostree_fetcher_request_uri_with_partial_async (OstreeFetcher         *self,
                                                     SoupURI               *uri,
                                                     guint64                max_size,
+                                                    int                    priority,
                                                     GCancellable          *cancellable,
                                                     GAsyncReadyCallback    callback,
                                                     gpointer               user_data);

--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -518,6 +518,7 @@ try_next_url (OstreeMetalinkRequest          *self)
       
       _ostree_fetcher_request_uri_with_partial_async (self->metalink->fetcher, next,
                                                       self->metalink->max_size,
+                                                      OSTREE_FETCHER_DEFAULT_PRIORITY,
                                                       g_task_get_cancellable (self->task),
                                                       on_fetched_url, self->task);
     }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -189,6 +189,10 @@ update_progress (gpointer user_data)
   ostree_async_progress_set_uint64 (pull_data->progress, "bytes-transferred", bytes_transferred);
   ostree_async_progress_set_uint64 (pull_data->progress, "start-time", start_time);
 
+  /* We fetch metadata before content.  These allow us to report metadata fetch progress specifically. */
+  ostree_async_progress_set_uint (pull_data->progress, "outstanding-metadata-fetches", pull_data->n_outstanding_metadata_fetches);
+  ostree_async_progress_set_uint (pull_data->progress, "metadata-fetched", pull_data->n_fetched_metadata);
+
   if (pull_data->fetching_sync_uri)
     {
       gs_free char *uri_string = soup_uri_to_string (pull_data->fetching_sync_uri, TRUE);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1123,6 +1123,7 @@ enqueue_one_object_request (OtPullData        *pull_data,
 
   _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, obj_uri,
                                                   expected_max_size,
+                                                  OSTREE_FETCHER_DEFAULT_PRIORITY,
                                                   pull_data->cancellable,
                                                   is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
   soup_uri_free (obj_uri);
@@ -1451,6 +1452,7 @@ process_one_static_delta (OtPullData   *pull_data,
 
       target_uri = suburi_new (pull_data->base_uri, deltapart_path, NULL);
       _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, target_uri, size,
+                                                      OSTREE_FETCHER_DEFAULT_PRIORITY,
                                                       pull_data->cancellable,
                                                       static_deltapart_fetch_on_complete,
                                                       fetch_data);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -29,6 +29,9 @@
 #include "ostree-metalink.h"
 #include "otutil.h"
 
+#define OSTREE_REPO_PULL_CONTENT_PRIORITY  (OSTREE_FETCHER_DEFAULT_PRIORITY)
+#define OSTREE_REPO_PULL_METADATA_PRIORITY (OSTREE_REPO_PULL_CONTENT_PRIORITY - 100)
+
 typedef struct {
   OstreeRepo   *repo;
   OstreeRepoPullFlags flags;
@@ -1123,7 +1126,8 @@ enqueue_one_object_request (OtPullData        *pull_data,
 
   _ostree_fetcher_request_uri_with_partial_async (pull_data->fetcher, obj_uri,
                                                   expected_max_size,
-                                                  OSTREE_FETCHER_DEFAULT_PRIORITY,
+                                                  is_meta ? OSTREE_REPO_PULL_METADATA_PRIORITY
+                                                          : OSTREE_REPO_PULL_CONTENT_PRIORITY,
                                                   pull_data->cancellable,
                                                   is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch_data);
   soup_uri_free (obj_uri);


### PR DESCRIPTION
This addresses items 1 and 2 of https://bugzilla.gnome.org/show_bug.cgi?id=740276

Not sure if we already have item 3 or what would be entailed there.  Testing this was more challenging than the patch itself, and I'm still trying to figure out a good way to induce a large pull on demand.  But from what I could tell the total objects to be downloaded didn't seem to increase once all the metadata was known.

I imagine there's some followup work to be done, but see what you think of this so far.