### PR TITLE
static-delta: do not accept both --from=REV and --empty for generate

### DIFF
--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -157,6 +157,12 @@ ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellab
 
       if (opt_empty)
         {
+          if (opt_from_rev)
+            {
+              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                   "Cannot specify both --empty and --from=REV");
+              goto out;
+            }
           from_source = NULL;
         }
       else if (opt_from_rev == NULL)

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -68,6 +68,10 @@ ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev}
 
 ostree --repo=repo static-delta list | grep ${origrev}-${newrev} || exit 1
 
+if ${CMD_PREFIX} ostree --repo=repo static-delta generate --from=${origrev} --to=${newrev} --empty 2>>err.txt; then
+    assert_not_reached "static-delta generate --from=${origrev} --empty unexpectedly succeeded"
+fi
+
 origstart=$(echo ${origrev} | dd bs=1 count=2 2>/dev/null)
 origend=$(echo ${origrev} | dd bs=1 skip=2 2>/dev/null)
 assert_has_dir repo/deltas/${origstart}/${origend}-${newrev}


### PR DESCRIPTION
a small thing I've noticed while browsing the new code