### PR TITLE
fetcher and deltas cleanup

### DIFF
--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -229,6 +229,16 @@ gboolean ostree_content_file_parse (gboolean                compressed,
                                     GCancellable           *cancellable,
                                     GError                **error);
 
+gboolean ostree_content_file_parse_at (gboolean                compressed,
+                                       int                     parent_dfd,
+                                       const char             *path,
+                                       gboolean                trusted,
+                                       GInputStream          **out_input,
+                                       GFileInfo             **out_file_info,
+                                       GVariant              **out_xattrs,
+                                       GCancellable           *cancellable,
+                                       GError                **error);
+
 gboolean ostree_raw_file_to_content_stream (GInputStream       *input,
                                             GFileInfo          *file_info,
                                             GVariant           *xattrs,

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -54,8 +54,10 @@ typedef enum {
 
 GType   _ostree_fetcher_get_type (void) G_GNUC_CONST;
 
-OstreeFetcher *_ostree_fetcher_new (GFile                     *tmpdir,
-                                   OstreeFetcherConfigFlags   flags);
+OstreeFetcher *_ostree_fetcher_new (int                     tmpdir_dfd,
+                                    OstreeFetcherConfigFlags   flags);
+
+int  _ostree_fetcher_get_dfd (OstreeFetcher *fetcher);
 
 void _ostree_fetcher_set_proxy (OstreeFetcher *fetcher,
                                 const char    *proxy);
@@ -76,7 +78,7 @@ void _ostree_fetcher_request_uri_with_partial_async (OstreeFetcher         *self
                                                     GAsyncReadyCallback    callback,
                                                     gpointer               user_data);
 
-GFile *_ostree_fetcher_request_uri_with_partial_finish (OstreeFetcher *self,
+char *_ostree_fetcher_request_uri_with_partial_finish (OstreeFetcher *self,
                                                        GAsyncResult  *result,
                                                        GError       **error);
 

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -53,7 +53,7 @@ SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         GMainLoop             *loop,
                                         SoupURI               **out_target_uri,
-                                        GFile                 **out_data,
+                                        char                  **out_data,
                                         SoupURI               **fetching_sync_uri,
                                         GCancellable          *cancellable,
                                         GError                **error);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -857,6 +857,12 @@ static_deltapart_fetch_on_complete (GObject           *object,
     delta_data = g_mapped_file_get_bytes (mfile);
     g_mapped_file_unref (mfile);
 
+    /* Unlink now while we're holding an open fd, so that on success
+     * or error, the file will be gone.  This is particularly
+     * important if say we hit e.g. ENOSPC.
+     */
+    (void) unlinkat (pull_data->tmpdir_dfd, temp_path, 0); 
+
     _ostree_static_delta_part_execute_async (pull_data->repo,
                                              fetch_data->objects,
                                              delta_data,

--- a/src/libotutil/ot-checksum-utils.c
+++ b/src/libotutil/ot-checksum-utils.c
@@ -92,7 +92,7 @@ ot_gio_splice_update_checksum (GOutputStream  *out,
         }
       while (bytes_read > 0);
     }
-  else
+  else if (out != NULL)
     {
       if (g_output_stream_splice (out, in, 0, cancellable, error) < 0)
         goto out;

--- a/src/libotutil/ot-variant-utils.c
+++ b/src/libotutil/ot-variant-utils.c
@@ -167,7 +167,7 @@ variant_map_data_destroy (gpointer data)
 }
 
 gboolean
-ot_util_variant_map_fd (GFileDescriptorBased  *stream,
+ot_util_variant_map_fd (int                    fd,
                         goffset                start,
                         const GVariantType    *type,
                         gboolean               trusted,
@@ -180,12 +180,14 @@ ot_util_variant_map_fd (GFileDescriptorBased  *stream,
   VariantMapData *mdata = NULL;
   gsize len;
 
-  if (!gs_stream_fstat (stream, &stbuf, NULL, error))
-    goto out;
+  if (fstat (fd, &stbuf) != 0)
+    {
+      gs_set_error_from_errno (error, errno);
+      goto out;
+    }
 
   len = stbuf.st_size - start;
-  map = mmap (NULL, len, PROT_READ, MAP_PRIVATE, 
-              g_file_descriptor_based_get_fd (stream), start);
+  map = mmap (NULL, len, PROT_READ, MAP_PRIVATE, fd, start);
   if (!map)
     {
       gs_set_error_from_errno (error, errno);

--- a/src/libotutil/ot-variant-utils.h
+++ b/src/libotutil/ot-variant-utils.h
@@ -48,7 +48,7 @@ gboolean ot_util_variant_map (GFile *src,
                               GVariant **out_variant,
                               GError  **error);
 
-gboolean ot_util_variant_map_fd (GFileDescriptorBased *stream,
+gboolean ot_util_variant_map_fd (int                  fd,
                                  goffset              offset,
                                  const GVariantType  *type,
                                  gboolean             trusted,


### PR DESCRIPTION
A small prelude, then a major rework of OstreeFetcher to use dirfd-relative API, leading to a few static deltas fixes.
