### PR TITLE
admin: Add set-origin command

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -60,6 +60,7 @@ ostree_SOURCES += \
 	src/ostree/ot-admin-builtin-instutil.c \
 	src/ostree/ot-admin-builtin-cleanup.c \
 	src/ostree/ot-admin-builtin-os-init.c \
+	src/ostree/ot-admin-builtin-set-origin.c \
 	src/ostree/ot-admin-builtin-status.c \
 	src/ostree/ot-admin-builtin-switch.c \
 	src/ostree/ot-admin-builtin-upgrade.c \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -128,7 +128,7 @@ include $(top_srcdir)/gtk-doc.make
 man1_MANS =
 
 if ENABLE_GTK_DOC
-man1_MANS += ostree.1 ostree.repo.5 ostree.repo-config.5 ostree-admin-cleanup.1 ostree-admin-config-diff.1 ostree-admin-deploy.1 ostree-admin-init-fs.1 ostree-admin-instutil.1 ostree-admin-os-init.1 ostree-admin-status.1 ostree-admin-switch.1 ostree-admin-undeploy.1 ostree-admin-upgrade.1 ostree-admin.1 ostree-cat.1 ostree-checkout.1 ostree-checksum.1 ostree-commit.1 ostree-config.1 ostree-diff.1 ostree-fsck.1 ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 ostree-pull.1 ostree-refs.1 ostree-remote.1 ostree-reset.1 ostree-rev-parse.1 ostree-show.1 ostree-summary.1 ostree-static-delta.1 ostree-trivial-httpd.1
+man1_MANS += ostree.1 ostree.repo.5 ostree.repo-config.5 ostree-admin-cleanup.1 ostree-admin-config-diff.1 ostree-admin-deploy.1 ostree-admin-init-fs.1 ostree-admin-instutil.1 ostree-admin-os-init.1 ostree-admin-status.1 ostree-admin-set-origin.1 ostree-admin-switch.1 ostree-admin-undeploy.1 ostree-admin-upgrade.1 ostree-admin.1 ostree-cat.1 ostree-checkout.1 ostree-checksum.1 ostree-commit.1 ostree-config.1 ostree-diff.1 ostree-fsck.1 ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 ostree-pull.1 ostree-refs.1 ostree-remote.1 ostree-reset.1 ostree-rev-parse.1 ostree-show.1 ostree-summary.1 ostree-static-delta.1 ostree-trivial-httpd.1
 
 
 XSLTPROC_FLAGS = \

--- a/doc/ostree-admin.xml
+++ b/doc/ostree-admin.xml
@@ -72,6 +72,7 @@ Boston, MA 02111-1307, USA.
             <listitem><para><command>instutil</command></para></listitem>
             <listitem><para><command>os-init</command></para></listitem>
             <listitem><para><command>status</command></para></listitem>
+            <listitem><para><command>set-origin</command></para></listitem>
             <listitem><para><command>switch</command></para></listitem>
             <listitem><para><command>undeploy</command></para></listitem>
             <listitem><para><command>upgrade</command></para></listitem>            

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -949,14 +949,28 @@ merge_configuration (OstreeSysroot         *sysroot,
   return ret;
 }
 
-static gboolean
-write_origin_file (OstreeSysroot         *sysroot,
-                   OstreeDeployment      *deployment,
-                   GCancellable      *cancellable,
-                   GError           **error)
+/**
+ * ostree_sysroot_write_origin_file:
+ * @sysroot: System root
+ * @deployment: Deployment
+ * @new_origin: (allow-none): Origin content
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Immediately replace the origin file of the referenced @deployment
+ * with the contents of @new_origin.  If @new_origin is %NULL,
+ * this function will write the current origin of @deployment.
+ */
+gboolean
+ostree_sysroot_write_origin_file (OstreeSysroot         *sysroot,
+                                  OstreeDeployment      *deployment,
+                                  GKeyFile              *new_origin,
+                                  GCancellable          *cancellable,
+                                  GError               **error)
 {
   gboolean ret = FALSE;
-  GKeyFile *origin = ostree_deployment_get_origin (deployment);
+  GKeyFile *origin =
+    new_origin ? new_origin : ostree_deployment_get_origin (deployment);
 
   if (origin)
     {
@@ -1879,7 +1893,8 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
       goto out;
     }
 
-  if (!write_origin_file (self, new_deployment, cancellable, error))
+  if (!ostree_sysroot_write_origin_file (self, new_deployment, NULL,
+                                         cancellable, error))
     {
       g_prefix_error (error, "Writing out origin file: ");
       goto out;

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -61,6 +61,12 @@ gboolean ostree_sysroot_cleanup (OstreeSysroot       *self,
                                  GCancellable        *cancellable,
                                  GError             **error);
 
+gboolean ostree_sysroot_write_origin_file (OstreeSysroot         *sysroot,
+                                           OstreeDeployment      *deployment,
+                                           GKeyFile              *new_origin,
+                                           GCancellable          *cancellable,
+                                           GError               **error);
+
 gboolean ostree_sysroot_get_repo (OstreeSysroot         *self,
                                   OstreeRepo           **out_repo,
                                   GCancellable          *cancellable,

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -1,0 +1,146 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "ot-main.h"
+#include "ot-admin-builtins.h"
+#include "ot-admin-functions.h"
+#include "ostree.h"
+#include "ot-tool-util.h"
+#include "otutil.h"
+#include "libgsystem.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <glib/gi18n.h>
+
+static int opt_index = -1;
+static char **opt_set;
+
+static GOptionEntry options[] = {
+  { "set", 's', 0, G_OPTION_ARG_STRING_ARRAY, &opt_set, "Set config option KEY=VALUE for remote", "KEY=VALUE" },
+  { "index", 0, 0, G_OPTION_ARG_INT, &opt_index, "Operate on the deployment INDEX, starting from zero", "INDEX" },
+  { NULL }
+};
+
+gboolean
+ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  gboolean ret = FALSE;
+  GOptionContext *context;
+  const char *remotename = NULL;
+  const char *url = NULL;
+  const char *branch = NULL;
+  gs_unref_object OstreeRepo *repo = NULL;
+  gs_unref_object OstreeSysroot *sysroot = NULL;
+  OstreeDeployment *target_deployment = NULL;
+
+  context = g_option_context_new ("REMOTENAME URL [BRANCH]");
+
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+    goto out;
+
+  if (argc < 3)
+    {
+      ot_util_usage_error (context, "REMOTENAME and URL must be specified", error);
+      goto out;
+    }
+
+  remotename = argv[1];
+  url = argv[2];
+  if (argc > 3)
+    branch = argv[3];
+
+  if (!ostree_sysroot_load (sysroot, cancellable, error))
+    goto out;
+
+  if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
+    goto out;
+
+  if (opt_index == -1)
+    {
+      target_deployment = ostree_sysroot_get_booted_deployment (sysroot);
+      if (target_deployment == NULL)
+        {
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "Not currently booted into an OSTree system");
+          goto out;
+        }
+    }
+  else
+    {
+      target_deployment = ot_admin_get_indexed_deployment (sysroot, opt_index, error);
+      if (!target_deployment)
+        goto out;
+    }
+
+  { char **iter;
+    gs_unref_variant_builder GVariantBuilder *optbuilder =
+      g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
+
+    for (iter = opt_set; iter && *iter; iter++)
+      {
+        const char *keyvalue = *iter;
+        gs_free char *subkey = NULL;
+        gs_free char *subvalue = NULL;
+
+        if (!ot_parse_keyvalue (keyvalue, &subkey, &subvalue, error))
+          goto out;
+
+        g_variant_builder_add (optbuilder, "{s@v}",
+                               subkey, g_variant_new_variant (g_variant_new_string (subvalue)));
+      }
+    
+    if (!ostree_repo_remote_change (repo, NULL,
+                                    OSTREE_REPO_REMOTE_CHANGE_ADD_IF_NOT_EXISTS, 
+                                    remotename, url,
+                                    g_variant_builder_end (optbuilder),
+                                    cancellable, error))
+      goto out;
+  }
+  
+  { GKeyFile *old_origin = ostree_deployment_get_origin (target_deployment);
+    gs_free char *origin_refspec = g_key_file_get_string (old_origin, "origin", "refspec", NULL);
+    gs_free char *new_refspec = NULL;
+    gs_free char *origin_remote = NULL;
+    gs_free char *origin_ref = NULL;
+  
+    if (!ostree_parse_refspec (origin_refspec, &origin_remote, &origin_ref, error))
+      goto out;
+
+    { gs_free char *new_refspec = g_strconcat (remotename, ":", branch ? branch : origin_ref, NULL);
+      gs_unref_keyfile GKeyFile *new_origin = NULL;
+      gs_unref_object GFile *origin_path = NULL;
+      
+      new_origin = ostree_sysroot_origin_new_from_refspec (sysroot, new_refspec);
+
+      if (!ostree_sysroot_write_origin_file (sysroot, target_deployment, new_origin,
+                                             cancellable, error))
+        goto out;
+    }
+  }
+
+  ret = TRUE;
+ out:
+  if (context)
+    g_option_context_free (context);
+  return ret;
+}

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -62,20 +62,10 @@ ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GEr
   deploy_index_str = argv[1];
   deploy_index = atoi (deploy_index_str);
 
-  if (deploy_index < 0)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "Invalid index %d", deploy_index);
-      goto out;
-    }
-  if (deploy_index >= current_deployments->len)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "Out of range index %d, expected < %d", deploy_index, current_deployments->len);
-      goto out;
-    }
-  
-  target_deployment = g_object_ref (current_deployments->pdata[deploy_index]);
+  target_deployment = ot_admin_get_indexed_deployment (sysroot, deploy_index, error);
+  if (!target_deployment)
+    goto out;
+
   if (target_deployment == ostree_sysroot_get_booted_deployment (sysroot))
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,

--- a/src/ostree/ot-admin-builtins.h
+++ b/src/ostree/ot-admin-builtins.h
@@ -35,6 +35,7 @@ gboolean ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancell
 gboolean ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GError **error);

--- a/src/ostree/ot-admin-functions.c
+++ b/src/ostree/ot-admin-functions.c
@@ -71,3 +71,30 @@ ot_admin_checksum_version (GVariant *checksum)
 
   return g_strdup (ret);
 }
+
+OstreeDeployment *
+ot_admin_get_indexed_deployment (OstreeSysroot  *sysroot,
+                                 int             index,
+                                 GError        **error)
+
+{
+  gs_unref_ptrarray GPtrArray *current_deployments =
+    ostree_sysroot_get_deployments (sysroot);
+
+  if (index < 0)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "Invalid index %d", index);
+      return NULL;
+    }
+  if (index >= current_deployments->len)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "Out of range deployment index %d, expected < %d", index,
+                   current_deployments->len);
+      return NULL;
+    }
+  
+  return g_object_ref (current_deployments->pdata[index]);
+}
+

--- a/src/ostree/ot-admin-functions.h
+++ b/src/ostree/ot-admin-functions.h
@@ -36,5 +36,11 @@ ot_admin_require_booted_deployment_or_osname (OstreeSysroot       *sysroot,
 char *
 ot_admin_checksum_version (GVariant *checksum);
 
+OstreeDeployment *
+ot_admin_get_indexed_deployment (OstreeSysroot  *sysroot,
+                                 int             index,
+                                 GError        **error);
+
+
 G_END_DECLS
 

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -44,6 +44,7 @@ static OstreeAdminCommand admin_subcommands[] = {
   { "init-fs", ot_admin_builtin_init_fs },
   { "instutil", ot_admin_builtin_instutil },
   { "os-init", ot_admin_builtin_os_init },
+  { "set-origin", ot_admin_builtin_set_origin },
   { "status", ot_admin_builtin_status },
   { "switch", ot_admin_builtin_switch },
   { "undeploy", ot_admin_builtin_undeploy },

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -25,6 +25,7 @@
 #include "ot-main.h"
 #include "ot-builtins.h"
 #include "ostree.h"
+#include "ot-tool-util.h"
 #include "otutil.h"
 
 static void
@@ -33,24 +34,6 @@ usage_error (GOptionContext *context, const char *message, GError **error)
   gs_free gchar *help = g_option_context_get_help (context, TRUE, NULL);
   g_printerr ("%s", help);
   g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
-}
-
-static gboolean
-parse_keyvalue (const char  *keyvalue,
-                char       **out_key,
-                char       **out_value,
-                GError     **error)
-{
-  const char *eq = strchr (keyvalue, '=');
-  if (!eq)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Missing '=' in KEY=VALUE for --set");
-      return FALSE;
-    }
-  *out_key = g_strndup (keyvalue, eq - keyvalue);
-  *out_value = g_strdup (eq + 1);
-  return TRUE;
 }
 
 static char **opt_set;
@@ -114,7 +97,7 @@ ostree_remote_builtin_add (int argc, char **argv, GCancellable *cancellable, GEr
       gs_free char *subkey = NULL;
       gs_free char *subvalue = NULL;
 
-      if (!parse_keyvalue (keyvalue, &subkey, &subvalue, error))
+      if (!ot_parse_keyvalue (keyvalue, &subkey, &subvalue, error))
         goto out;
 
       g_variant_builder_add (optbuilder, "{s@v}",

--- a/src/ostree/ot-tool-util.c
+++ b/src/ostree/ot-tool-util.c
@@ -51,3 +51,21 @@ ot_parse_boolean (const char  *option_name,
 
   return TRUE;
 }
+
+gboolean
+ot_parse_keyvalue (const char  *keyvalue,
+                   char       **out_key,
+                   char       **out_value,
+                   GError     **error)
+{
+  const char *eq = strchr (keyvalue, '=');
+  if (!eq)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Missing '=' in KEY=VALUE for --set");
+      return FALSE;
+    }
+  *out_key = g_strndup (keyvalue, eq - keyvalue);
+  *out_value = g_strdup (eq + 1);
+  return TRUE;
+}

--- a/src/ostree/ot-tool-util.h
+++ b/src/ostree/ot-tool-util.h
@@ -30,6 +30,11 @@ ot_parse_boolean (const char  *option_name,
                   const char  *value,
                   gboolean    *out_parsed,
                   GError     **error);
+gboolean
+ot_parse_keyvalue (const char  *keyvalue,
+                   char       **out_key,
+                   char       **out_value,
+                   GError     **error);
 
 G_END_DECLS
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -148,6 +148,16 @@ ostree admin --sysroot=sysroot status
 
 echo "ok upgrade"
 
+originfile=$(ostree admin --sysroot=sysroot --print-current-dir).origin
+cp ${originfile} saved-origin
+ostree admin --sysroot=sysroot set-origin --index=0 bacon --set=gpg-verify=false http://tasty.com
+assert_file_has_content "${originfile}" "bacon:testos/buildmaster/x86_64-runtime"
+ostree --repo=sysroot/ostree/repo remote list -u > remotes.txt
+assert_file_has_content remotes.txt 'bacon.*http://tasty.com'
+cp saved-origin ${originfile}
+
+echo "ok set-origin"
+
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${rev}.0/etc/os-release 'NAME=TestOS'
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${newrev}.0/etc/os-release 'NAME=TestOS'
 ostree admin --sysroot=sysroot undeploy 1


### PR DESCRIPTION
See https://github.com/projectatomic/rpm-ostree/issues/42 for
rationale.  There are two high level use cases:

 - If OS comes unconfigured, this is a way
   to point it at a repo of your choice.
 - To switch between repositories while keeping the same branch
   easily.