### PR TITLE
static-delta: limit the number of writes in process to 10

### DIFF
--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -265,6 +265,11 @@ _ostree_static_delta_part_execute_raw (OstreeRepo      *repo,
       guint8 opcode;
       OstreeStaticDeltaOperation *op;
 
+      /* Limit the number of outstanding writes to 1 to prevent too many open files
+         at the same time.  */
+      while (state->outstanding_content_writes > 1)
+        g_main_context_iteration (state->content_writing_context, TRUE);
+
       if (state->object_start)
         {
           if (!open_output_target (state, cancellable, error))


### PR DESCRIPTION
This will avoid too many open files at the same time that could cause
an EMFILE error.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>