### PR TITLE
Fail early when user lacks write permission

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -201,6 +201,7 @@ ostree_repo_new_default
 ostree_repo_open
 ostree_repo_set_disable_fsync
 ostree_repo_is_system
+ostree_repo_is_writable
 ostree_repo_create
 ostree_repo_get_path
 ostree_repo_get_mode

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -65,6 +65,7 @@ struct OstreeRepo {
 
   gboolean inited;
   gboolean writable;
+  GError *writable_error;
   gboolean in_transaction;
   gboolean disable_fsync;
   GHashTable *loose_object_devino_hash;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -54,6 +54,9 @@ void          ostree_repo_set_disable_fsync (OstreeRepo    *self,
 
 gboolean      ostree_repo_is_system (OstreeRepo   *repo);
 
+gboolean      ostree_repo_is_writable (OstreeRepo  *self,
+                                       GError     **error);
+
 gboolean      ostree_repo_create (OstreeRepo     *self,
                                   OstreeRepoMode  mode,
                                   GCancellable   *cancellable,

--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -43,7 +43,9 @@ ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GErr
 
   context = g_option_context_new ("Delete untagged deployments and repository objects");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-builtin-cleanup.c
+++ b/src/ostree/ot-admin-builtin-cleanup.c
@@ -44,7 +44,7 @@ ot_admin_builtin_cleanup (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("Delete untagged deployments and repository objects");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -67,7 +67,7 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
   context = g_option_context_new ("REFSPEC - Checkout revision REFSPEC as the new default deployment");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -66,7 +66,9 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
 
   context = g_option_context_new ("REFSPEC - Checkout revision REFSPEC as the new default deployment");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc < 2)

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -56,7 +56,7 @@ ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError 
   g_option_context_add_main_entries (context, options, NULL);
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
   

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -55,7 +55,9 @@ ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError 
 
   g_option_context_add_main_entries (context, options, NULL);
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
   
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -49,7 +49,7 @@ ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("PATH - Initialize a root filesystem");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -48,7 +48,9 @@ ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GErr
 
   context = g_option_context_new ("PATH - Initialize a root filesystem");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc < 2)

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -116,7 +116,9 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
       context = ostree_admin_instutil_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (ostree_admin_option_context_parse (context, NULL, &argc, &argv, NULL, cancellable, error))
+      if (ostree_admin_option_context_parse (context, NULL, &argc, &argv,
+                                             OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                             NULL, cancellable, error))
         {
           if (subcommand_name == NULL)
             {

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -117,7 +117,7 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
       /* This will not return for some options (e.g. --version). */
       if (ostree_admin_option_context_parse (context, NULL, &argc, &argv,
-                                             OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                             OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                              NULL, cancellable, error))
         {
           if (subcommand_name == NULL)

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -46,7 +46,9 @@ ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GErr
 
   context = g_option_context_new ("OSNAME - Initialize empty state for given operating system");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_ensure_initialized (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -47,7 +47,7 @@ ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("OSNAME - Initialize empty state for given operating system");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -55,7 +55,9 @@ ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, G
 
   context = g_option_context_new ("REMOTENAME URL [BRANCH]");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc < 3)

--- a/src/ostree/ot-admin-builtin-set-origin.c
+++ b/src/ostree/ot-admin-builtin-set-origin.c
@@ -56,7 +56,7 @@ ot_admin_builtin_set_origin (int argc, char **argv, GCancellable *cancellable, G
   context = g_option_context_new ("REMOTENAME URL [BRANCH]");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-status.c
+++ b/src/ostree/ot-admin-builtin-status.c
@@ -62,7 +62,9 @@ ot_admin_builtin_status (int argc, char **argv, GCancellable *cancellable, GErro
 
   context = g_option_context_new ("List deployments");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -68,7 +68,9 @@ ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GErro
 
   context = g_option_context_new ("REF - Construct new tree from current origin and deploy it, if it changed");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc < 2)

--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -69,7 +69,7 @@ ot_admin_builtin_switch (int argc, char **argv, GCancellable *cancellable, GErro
   context = g_option_context_new ("REF - Construct new tree from current origin and deploy it, if it changed");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -46,7 +46,9 @@ ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GEr
 
   context = g_option_context_new ("INDEX - Delete deployment INDEX");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc < 2)

--- a/src/ostree/ot-admin-builtin-undeploy.c
+++ b/src/ostree/ot-admin-builtin-undeploy.c
@@ -47,7 +47,7 @@ ot_admin_builtin_undeploy (int argc, char **argv, GCancellable *cancellable, GEr
   context = g_option_context_new ("INDEX - Delete deployment INDEX");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -68,7 +68,7 @@ ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("Construct new tree from current origin and deploy it, if it changed");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-upgrade.c
+++ b/src/ostree/ot-admin-builtin-upgrade.c
@@ -67,7 +67,9 @@ ot_admin_builtin_upgrade (int argc, char **argv, GCancellable *cancellable, GErr
 
   context = g_option_context_new ("Construct new tree from current origin and deploy it, if it changed");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -47,7 +47,9 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
 
   context = g_option_context_new ("[BOOTVERSION] - generate GRUB2 configuration from given BLS entries");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (argc >= 2)

--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -48,7 +48,7 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
   context = g_option_context_new ("[BOOTVERSION] - generate GRUB2 configuration from given BLS entries");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -194,7 +194,9 @@ ot_admin_instutil_builtin_selinux_ensure_labeled (int argc, char **argv, GCancel
 
   context = g_option_context_new ("[SUBPATH PREFIX] - relabel all or part of a deployment");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
+++ b/src/ostree/ot-admin-instutil-builtin-selinux-ensure-labeled.c
@@ -195,7 +195,7 @@ ot_admin_instutil_builtin_selinux_ensure_labeled (int argc, char **argv, GCancel
   context = g_option_context_new ("[SUBPATH PREFIX] - relabel all or part of a deployment");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -57,7 +57,7 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, GCancellable *cancel
   context = g_option_context_new ("ARGS - set new kernel command line arguments");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-instutil-builtin-set-kargs.c
+++ b/src/ostree/ot-admin-instutil-builtin-set-kargs.c
@@ -56,7 +56,9 @@ ot_admin_instutil_builtin_set_kargs (int argc, char **argv, GCancellable *cancel
 
   context = g_option_context_new ("ARGS - set new kernel command line arguments");
 
-  if (!ostree_admin_option_context_parse (context, options, &argc, &argv, &sysroot, cancellable, error))
+  if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                          &sysroot, cancellable, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-builtin-admin.c
+++ b/src/ostree/ot-builtin-admin.c
@@ -130,7 +130,9 @@ ostree_builtin_admin (int argc, char **argv, GCancellable *cancellable, GError *
       context = ostree_admin_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (ostree_admin_option_context_parse (context, NULL, &argc, &argv, NULL, cancellable, error))
+      if (ostree_admin_option_context_parse (context, NULL, &argc, &argv,
+                                             OSTREE_ADMIN_BUILTIN_FLAG_NONE,
+                                             NULL, cancellable, error))
         {
           if (subcommand_name == NULL)
             {

--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -317,6 +317,9 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (opt_statoverride_file)
     {
       if (!parse_statoverride_file (&mode_adds, cancellable, error))

--- a/src/ostree/ot-builtin-prune.c
+++ b/src/ostree/ot-builtin-prune.c
@@ -55,6 +55,9 @@ ostree_builtin_prune (int argc, char **argv, GCancellable *cancellable, GError *
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!opt_no_prune && !ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (opt_refs_only)
     pruneflags |= OSTREE_REPO_PRUNE_FLAGS_REFS_ONLY;
   if (opt_no_prune)

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -58,6 +58,9 @@ ostree_builtin_pull_local (int argc, char **argv, GCancellable *cancellable, GEr
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (argc < 2)
     {
       gchar *help = g_option_context_get_help (context, TRUE, NULL);

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -57,6 +57,9 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (argc < 2)
     {
       ot_util_usage_error (context, "REMOTE must be specified", error);

--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -100,6 +100,9 @@ ostree_builtin_reset (int           argc,
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (argc <= 2)
     {
       ot_util_usage_error (context, "A ref and commit argument is required", error);

--- a/src/ostree/ot-builtin-static-delta.c
+++ b/src/ostree/ot-builtin-static-delta.c
@@ -138,6 +138,9 @@ ot_static_delta_builtin_generate (int argc, char **argv, GCancellable *cancellab
   if (!ostree_option_context_parse (context, generate_options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
 
+  if (!ostree_ensure_repo_writable (repo, error))
+    goto out;
+
   if (argc >= 3 && opt_to_rev == NULL)
     opt_to_rev = argv[2];
 
@@ -239,6 +242,9 @@ ot_static_delta_builtin_apply_offline (int argc, char **argv, GCancellable *canc
 
   context = g_option_context_new ("DELTA - Apply static delta file");
   if (!ostree_option_context_parse (context, apply_offline_options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    goto out;
+
+  if (!ostree_ensure_repo_writable (repo, error))
     goto out;
 
   if (argc < 3)

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -46,6 +46,9 @@ ostree_builtin_summary (int argc, char **argv, GCancellable *cancellable, GError
 
   if (opt_update)
     {
+      if (!ostree_ensure_repo_writable (repo, error))
+        goto out;
+
       if (!ostree_repo_regenerate_summary (repo, NULL, cancellable, error))
         goto out;
     }

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -306,6 +306,7 @@ ostree_admin_option_context_parse (GOptionContext *context,
                                    const GOptionEntry *main_entries,
                                    int *argc,
                                    char ***argv,
+                                   OstreeAdminBuiltinFlags flags,
                                    OstreeSysroot **out_sysroot,
                                    GCancellable *cancellable,
                                    GError **error)

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -323,6 +323,16 @@ ostree_admin_option_context_parse (GOptionContext *context,
   if (!ostree_option_context_parse (context, main_entries, argc, argv, OSTREE_BUILTIN_FLAG_NO_REPO, NULL, cancellable, error))
     goto out;
 
+  if (flags & OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER)
+    {
+      if (getuid () != 0)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED,
+                       "You must be root to perform this command");
+          goto out;
+        }
+    }
+
   sysroot_path = g_file_new_for_path (opt_sysroot);
   sysroot = ostree_sysroot_new (sysroot_path);
 

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -358,3 +358,17 @@ ostree_admin_option_context_parse (GOptionContext *context,
 out:
   return success;
 }
+
+gboolean
+ostree_ensure_repo_writable (OstreeRepo *repo,
+                             GError **error)
+{
+  gboolean ret;
+
+  ret = ostree_repo_is_writable (repo, error);
+
+  g_prefix_error (error, "Cannot write to repository: ");
+
+  return ret;
+}
+

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -51,3 +51,5 @@ gboolean ostree_admin_option_context_parse (GOptionContext *context,
                                             int *argc, char ***argv,
                                             OstreeSysroot **out_sysroot,
                                             GCancellable *cancellable, GError **error);
+
+gboolean ostree_ensure_repo_writable (OstreeRepo *repo, GError **error);

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -32,6 +32,7 @@ typedef enum {
 
 typedef enum {
   OSTREE_ADMIN_BUILTIN_FLAG_NONE = 0,
+  OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER = 1 << 0
 } OstreeAdminBuiltinFlags;
 
 typedef struct {

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -30,6 +30,10 @@ typedef enum {
   OSTREE_BUILTIN_FLAG_NO_CHECK = 1 << 1
 } OstreeBuiltinFlags;
 
+typedef enum {
+  OSTREE_ADMIN_BUILTIN_FLAG_NONE = 0,
+} OstreeAdminBuiltinFlags;
+
 typedef struct {
   const char *name;
   gboolean (*fn) (int argc, char **argv, GCancellable *cancellable, GError **error);
@@ -49,6 +53,7 @@ gboolean ostree_option_context_parse (GOptionContext *context,
 gboolean ostree_admin_option_context_parse (GOptionContext *context,
                                             const GOptionEntry *main_entries,
                                             int *argc, char ***argv,
+                                            OstreeAdminBuiltinFlags flags,
                                             OstreeSysroot **out_sysroot,
                                             GCancellable *cancellable, GError **error);
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -368,3 +368,14 @@ mkdir -p test2-checkout
 cd test2-checkout
 touch should-not-be-fsynced
 $OSTREE commit -b test2 -s "Unfsynced commit" --fsync=false
+
+cd ${test_tmpdir}
+rm -f expected-fail error-message
+$OSTREE init --mode=archive-z2 --repo=repo-noperm
+chmod -w repo-noperm
+$OSTREE --repo=repo-noperm pull-local repo 2> error-message || touch expected-fail
+assert_has_file expected-fail
+assert_file_has_content error-message "Permission denied"
+chmod +w repo-noperm
+echo "ok unwritable repo was caught"
+


### PR DESCRIPTION
When running certain yum commands as an unprivileged user it fails quickly with a helpful "You must be root to perform this command."

I tried to do something similar for OSTree -- just the repo-related commands so far.  If you like this I can do something similar for the admin commands.

When reviewing, look out for any commands I may have missed.

Related to: https://bugzilla.gnome.org/show_bug.cgi?id=743040