### PR TITLE
pull: Implement --enable-syncfs

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -82,10 +82,12 @@ _ostree_repo_ensure_loose_objdir_at (int             dfd,
                                      const char     *loose_path,
                                      GCancellable   *cancellable,
                                      GError        **error);
-void
+gboolean
 _ostree_repo_get_tmpobject_path (char *output,
                                  const char *checksum,
-                                 OstreeObjectType objtype);
+                                 OstreeObjectType objtype,
+                                 GCancellable     *cancellable,
+                                 GError          **error);
 
 gboolean
 _ostree_repo_find_object (OstreeRepo           *self,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -82,6 +82,10 @@ _ostree_repo_ensure_loose_objdir_at (int             dfd,
                                      const char     *loose_path,
                                      GCancellable   *cancellable,
                                      GError        **error);
+void
+_ostree_repo_get_tmpobject_path (char *output,
+                                 const char *checksum,
+                                 OstreeObjectType objtype);
 
 gboolean
 _ostree_repo_find_object (OstreeRepo           *self,
@@ -101,6 +105,7 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
                                OstreeObjectType      objtype,
                                gboolean             *out_is_stored,
                                char                 *loose_path_buf,
+                               GFile               **out_stored_path,
                                GCancellable         *cancellable,
                                GError             **error);
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1715,6 +1715,13 @@ load_metadata_internal (OstreeRepo       *self,
                            cancellable, error))
     goto out;
 
+  if (self->in_transaction && fd < 0)
+    {
+      _ostree_repo_get_tmpobject_path (loose_path_buf, sha256, objtype);
+      if (!openat_allow_noent (self->tmp_dir_fd, loose_path_buf, &fd, cancellable, error))
+        goto out;
+    }
+
   if (fd != -1)
     {
       if (out_variant)
@@ -2111,27 +2118,55 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
                                OstreeObjectType      objtype,
                                gboolean             *out_is_stored,
                                char                 *loose_path_buf,
+                               GFile               **out_stored_path,
                                GCancellable         *cancellable,
                                GError             **error)
 {
   gboolean ret = FALSE;
   struct stat stbuf;
-  int res;
+  int res = -1;
+  gboolean tmp_file = FALSE;
 
-  _ostree_loose_path (loose_path_buf, checksum, objtype, self->mode);
-
-  do
-    res = fstatat (self->objects_dir_fd, loose_path_buf, &stbuf, AT_SYMLINK_NOFOLLOW);
-  while (G_UNLIKELY (res == -1 && errno == EINTR));
-  if (res == -1 && errno != ENOENT)
+  if (self->in_transaction)
     {
-      gs_set_error_from_errno (error, errno);
-      goto out;
+      _ostree_repo_get_tmpobject_path (loose_path_buf, checksum, objtype);
+      do
+        res = fstatat (self->tmp_dir_fd, loose_path_buf, &stbuf, AT_SYMLINK_NOFOLLOW);
+      while (G_UNLIKELY (res == -1 && errno == EINTR));
+      if (res == -1 && errno != ENOENT)
+        {
+          gs_set_error_from_errno (error, errno);
+          goto out;
+        }
+    }
+
+  if (res == 0)
+    tmp_file = TRUE;
+  else
+    {
+      _ostree_loose_path (loose_path_buf, checksum, objtype, self->mode);
+
+      do
+        res = fstatat (self->objects_dir_fd, loose_path_buf, &stbuf, AT_SYMLINK_NOFOLLOW);
+      while (G_UNLIKELY (res == -1 && errno == EINTR));
+      if (res == -1 && errno != ENOENT)
+        {
+          gs_set_error_from_errno (error, errno);
+          goto out;
+        }
     }
 
   ret = TRUE;
   *out_is_stored = (res != -1);
- out:
+
+  if (out_stored_path)
+    {
+      if (res != -1)
+        *out_stored_path = g_file_resolve_relative_path (tmp_file ? self->tmp_dir : self->objects_dir, loose_path_buf);
+      else
+        *out_stored_path = NULL;
+    }
+out:
   return ret;
 }
 
@@ -2143,21 +2178,10 @@ _ostree_repo_find_object (OstreeRepo           *self,
                           GCancellable         *cancellable,
                           GError             **error)
 {
-  gboolean ret = FALSE;
   gboolean has_object;
   char loose_path[_OSTREE_LOOSE_PATH_MAX];
-
-  if (!_ostree_repo_has_loose_object (self, checksum, objtype, &has_object, loose_path, 
-                                      cancellable, error))
-    goto out;
-
-  ret = TRUE;
-  if (has_object)
-    *out_stored_path = g_file_resolve_relative_path (self->objects_dir, loose_path);
-  else
-    *out_stored_path = NULL;
-out:
-  return ret;
+  return _ostree_repo_has_loose_object (self, checksum, objtype, &has_object, loose_path,
+                                        out_stored_path, cancellable, error);
 }
 
 /**

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1717,7 +1717,9 @@ load_metadata_internal (OstreeRepo       *self,
 
   if (self->in_transaction && fd < 0)
     {
-      _ostree_repo_get_tmpobject_path (loose_path_buf, sha256, objtype);
+      if (! _ostree_repo_get_tmpobject_path (loose_path_buf, sha256, objtype,
+                                             cancellable, error))
+        goto out;
       if (!openat_allow_noent (self->tmp_dir_fd, loose_path_buf, &fd, cancellable, error))
         goto out;
     }
@@ -2129,7 +2131,9 @@ _ostree_repo_has_loose_object (OstreeRepo           *self,
 
   if (self->in_transaction)
     {
-      _ostree_repo_get_tmpobject_path (loose_path_buf, checksum, objtype);
+      if (! _ostree_repo_get_tmpobject_path (loose_path_buf, checksum, objtype,
+                                             cancellable, error))
+        goto out;
       do
         res = fstatat (self->tmp_dir_fd, loose_path_buf, &stbuf, AT_SYMLINK_NOFOLLOW);
       while (G_UNLIKELY (res == -1 && errno == EINTR));


### PR DESCRIPTION
Differently than fsync that is called after each file is modified,
syncfs is used only once at the end of the pull to sync the file
system which contains the repository.

Results of pull on an empty repository:

$ LANG=C sudo time ./ostree --repo=repo --disable-fsync pull master master
0 metadata, 0 content objects fetched; 83524 KiB; 6 delta parts fetched, transferred in 5 seconds
17.09user 2.41system 0:05.77elapsed 337%CPU (0avgtext+0avgdata 296132maxresident)k
0inputs+868584outputs (0major+102828minor)pagefaults 0swaps

$ LANG=C sudo time ./ostree --repo=repo pull master master
0 metadata, 0 content objects fetched; 83524 KiB; 6 delta parts fetched, transferred in 401 seconds
17.31user 5.73system 6:41.33elapsed 5%CPU (0avgtext+0avgdata 296864maxresident)k
0inputs+868584outputs (0major+132664minor)pagefaults 0swaps

$ LANG=C sudo time ./ostree --repo=repo --enable-syncfs pull master master
0 metadata, 0 content objects fetched; 83524 KiB; 6 delta parts fetched, transferred in 6 seconds
17.14user 2.57system 0:10.60elapsed 185%CPU (0avgtext+0avgdata 296212maxresident)k
0inputs+868584outputs (0major+86783minor)pagefaults 0swaps

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>