### PR TITLE
commit: Fix segfault on async writes if object exists and checksum reque...

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -478,6 +478,8 @@ write_object (OstreeRepo         *self,
         goto out;
       if (have_obj)
         {
+          if (out_csum)
+            *out_csum = ostree_checksum_to_bytes (expected_checksum);
           ret = TRUE;
           goto out;
         }


### PR DESCRIPTION
...sted

If an object already existed and we somehow tried to pull it, the
caller would still expect a returned checksum.

This appears to happen with static deltas for some reason; we might be
including duplicate metadata objects.  Regardless, this is a bug that
should be fixed.