### PR TITLE
build: Add --disable-static-deltas

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,15 @@ AS_IF([test "x$found_introspection" = xyes], [
 ], [have_gjs=no])
 AM_CONDITIONAL(BUILDOPT_GJS, test x$have_gjs = xyes)
 
+AC_ARG_ENABLE(static_deltas,
+              AS_HELP_STRING([--disable-static-deltas],
+                             [Disable static delta code (default: no)]),,
+              [enable_static_deltas=yes])
+AS_IF([test x$enable_static_deltas = xyes], [
+    AC_DEFINE(BUILDOPT_STATIC_DELTAS, 1, [Define if static deltas are enabled])
+])
+AM_CONDITIONAL(BUILDOPT_STATIC_DELTAS, test x$enable_static_deltas = xyes)
+
 AC_CONFIG_FILES([
 Makefile
 doc/Makefile

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1965,12 +1965,14 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
                                     &from_revision, error))
         goto out;
 
+#ifdef BUILDOPT_STATIC_DELTAS
       if (from_revision == NULL || g_strcmp0 (from_revision, to_revision) != 0)
         {
           if (!request_static_delta_superblock_sync (pull_data, from_revision, to_revision,
                                                      &delta_superblock, cancellable, error))
             goto out;
         }
+#endif
           
       if (!delta_superblock)
         {


### PR DESCRIPTION
Since they're unstable, we want to allow organizations shipping ostree
now to be future proof against any changes.