### PR TITLE
Explicitly label .origin files as configuration

### DIFF
--- a/src/libostree/ostree-sepolicy.h
+++ b/src/libostree/ostree-sepolicy.h
@@ -62,5 +62,14 @@ gboolean ostree_sepolicy_restorecon (OstreeSePolicy   *self,
                                      GCancellable     *cancellable,
                                      GError          **error);
 
+gboolean ostree_sepolicy_setfscreatecon (OstreeSePolicy   *self,
+                                         const char       *path,
+                                         guint32           mode,
+                                         GError          **error);
+
+void ostree_sepolicy_fscreatecon_cleanup (void **unused);
+
+#define ostree_cleanup_sepolicy_fscreatecon __attribute__ ((cleanup(ostree_sepolicy_fscreatecon_cleanup)))
+
 G_END_DECLS
 

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -34,6 +34,8 @@ struct OstreeSysroot {
 
   gboolean loaded;
   
+  OstreeSePolicy *sepolicy;
+  
   GPtrArray *deployments;
   int bootversion;
   int subbootversion;

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -63,6 +63,7 @@ ostree_sysroot_finalize (GObject *object)
   OstreeSysroot *self = OSTREE_SYSROOT (object);
 
   g_clear_object (&self->path);
+  g_clear_object (&self->sepolicy);
 
   G_OBJECT_CLASS (ostree_sysroot_parent_class)->finalize (object);
 }


### PR DESCRIPTION
subscription-manager has a daemon that runs in a confined domain,
and it doesn't have permission to write usr_t, which is the default
label of /ostree/deploy/$osname/deploy.

A better long term fix is probably to move the origin file into the
deployment root as /etc/ostree/origin.conf or so.

In the meantime, let's ensure the .origin files are labeled as
configuration.