### PR TITLE
Add an API to set/unset a deployment tree's mutability

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1917,8 +1917,8 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                       cancellable, error))
     goto out;
 
-  if (!_ostree_linuxfs_alter_immutable_flag (new_deployment_path, TRUE,
-                                             cancellable, error))
+  if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
+                                              cancellable, error))
     goto out;
 
   { ostree_cleanup_sepolicy_fscreatecon gpointer dummy = NULL;
@@ -2009,6 +2009,35 @@ ostree_sysroot_deployment_set_kargs (OstreeSysroot     *self,
 
   if (!ostree_sysroot_write_deployments (self, new_deployments,
                                          cancellable, error))
+    goto out;
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+/**
+ * ostree_sysroot_deployment_set_mutable:
+ * @self: Sysroot
+ * @deployment: A deployment
+ * @mutable: Whether or not deployment's files can be changed
+ * @error: Error
+ *
+ * By default, deployment directories are not mutable.  This function
+ * will allow making them temporarily mutable, for example to allow
+ * layering additional non-OSTree content.
+ */
+gboolean
+ostree_sysroot_deployment_set_mutable (OstreeSysroot     *self,
+                                       OstreeDeployment  *deployment,
+                                       gboolean           mutable,
+                                       GCancellable      *cancellable,
+                                       GError           **error)
+{
+  gboolean ret = FALSE;
+  gs_unref_object GFile *path = ostree_sysroot_get_deployment_directory (self, deployment);
+
+  if (!_ostree_linuxfs_alter_immutable_flag (path, !mutable, cancellable, error))
     goto out;
 
   ret = TRUE;

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -93,6 +93,12 @@ gboolean ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                      GCancellable      *cancellable,
                                      GError           **error);
 
+gboolean ostree_sysroot_deployment_set_mutable (OstreeSysroot     *self,
+                                                OstreeDeployment  *deployment,
+                                                gboolean           mutable,
+                                                GCancellable      *cancellable,
+                                                GError           **error);
+
 OstreeDeployment *ostree_sysroot_get_merge_deployment (OstreeSysroot     *self,
                                                        const char        *osname);
 


### PR DESCRIPTION
This will be used by rpm-ostree to unset the immutable bit temporarily
in order to do package layering.  We could add an API to deploy a tree
without the immutable bit, but this is simpler.