### PR TITLE
repo: detached sigs: Use error prefixing instead of overwriting

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1925,6 +1925,7 @@ ostree_repo_read_commit_detached_metadata (OstreeRepo      *self,
         }
       else
         {
+          g_prefix_error (error, "Unable to read existing detached metadata: ");
           g_propagate_error (error, temp_error);
           goto out;
         }
@@ -1971,7 +1972,10 @@ ostree_repo_write_commit_detached_metadata (OstreeRepo      *self,
                                 g_variant_get_size (normalized),
                                 NULL, FALSE, 0, NULL,
                                 cancellable, error))
-    goto out;
+    {
+      g_prefix_error (error, "Unable to write detached metadata: ");
+      goto out;
+    }
 
   ret = TRUE;
  out:

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2995,11 +2995,7 @@ ostree_repo_append_gpg_signature (OstreeRepo     *self,
                                                   &metadata,
                                                   cancellable,
                                                   error))
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Unable to read existing detached metadata");
-      goto out;
-    }
+    goto out;
 
   new_metadata = _ostree_detached_metadata_append_gpg_sig (metadata, signature_bytes);
 
@@ -3008,11 +3004,7 @@ ostree_repo_append_gpg_signature (OstreeRepo     *self,
                                                    new_metadata,
                                                    cancellable,
                                                    error))
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Unable to read existing detached metadata");
-      goto out;
-    }
+    goto out;
 
   ret = TRUE;
  out:


### PR DESCRIPTION
Noted when "rpm-ostree compose sign" failed to write to a repo due to
permissions.