### PR TITLE
Rewrite OstreeGpgVerifier to use GPGME

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -89,8 +89,6 @@ libostree_1_la_SOURCES = \
 	src/libostree/ostree-bootloader-syslinux.c \
 	src/libostree/ostree-bootloader-uboot.h \
 	src/libostree/ostree-bootloader-uboot.c \
-	src/libostree/ostree-gpg-verifier.c \
-	src/libostree/ostree-gpg-verifier.h \
 	src/libostree/ostree-repo-static-delta-core.c \
 	src/libostree/ostree-repo-static-delta-processing.c \
 	src/libostree/ostree-repo-static-delta-compilation.c \
@@ -106,6 +104,12 @@ if HAVE_LIBSOUP_CLIENT_CERTS
 libostree_1_la_SOURCES += \
 	src/libostree/ostree-tls-cert-interaction.c \
 	src/libostree/ostree-tls-cert-interaction.h \
+	$(NULL)
+endif
+if USE_GPGME
+libostree_1_la_SOURCES += \
+	src/libostree/ostree-gpg-verifier.c \
+	src/libostree/ostree-gpg-verifier.h \
 	$(NULL)
 endif
 

--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -43,7 +43,7 @@ OstreeGpgVerifier *_ostree_gpg_verifier_new (GCancellable   *cancellable,
 
 gboolean      _ostree_gpg_verifier_check_signature (OstreeGpgVerifier *self,
                                                     GFile             *file,
-                                                    GFile             *signature,
+                                                    GBytes            *signatures,
                                                     gboolean          *had_valid_signature,
                                                     GCancellable      *cancellable,
                                                     GError           **error);


### PR DESCRIPTION
This sets the stage for more advanced signature management.

(Also, talking to GPG over pipes sucks.)

Previously we were spawning `gpgv2` with a bunch of `--keyring` options
for `/usr/share/ostree/trusted.gpg.d/` and whatever other keyring files
were explicitly added.  GPGME has no public API for multiple keyrings,
so we work around the issue by setting up a temp directory to serve as
a fake "home" directory for the crypto engine and then concatenate all
the keyring files into a single public keyring (`pubring.gpg`).

Unfortunately at present we do this on every signature verification.
There's a desire to cache this concatenation, but the problem is the
user may be unprivileged.  So it seems the cache would have to be per
user under `$XDG_CACHE_HOME`, which OSTree doesn't otherwise use.  I'm
open to suggestions.

We do at least clean up the temp directory when finished, and I have
further API changes planned to `OstreeGpgVerifier` to help mitigate the
performance impact.