### PR TITLE
OstreeGpgVerifier: Take the signed data as a GBytes

### DIFF
--- a/src/libostree/ostree-gpg-verifier.h
+++ b/src/libostree/ostree-gpg-verifier.h
@@ -42,7 +42,7 @@ OstreeGpgVerifier *_ostree_gpg_verifier_new (GCancellable   *cancellable,
                                              GError        **error);
 
 gboolean      _ostree_gpg_verifier_check_signature (OstreeGpgVerifier *self,
-                                                    GFile             *file,
+                                                    GBytes            *signed_data,
                                                     GBytes            *signatures,
                                                     gboolean          *had_valid_signature,
                                                     GCancellable      *cancellable,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -186,13 +186,13 @@ _ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
                                         GError     **error);
 
 gboolean
-_ostree_repo_gpg_verify_file_with_metadata (OstreeRepo          *self,
-                                            GFile               *path,
-                                            GVariant            *metadata,
-                                            GFile               *keyringdir,
-                                            GFile               *extra_keyring,
-                                            GCancellable        *cancellable,
-                                            GError             **error);
+_ostree_repo_gpg_verify_with_metadata (OstreeRepo          *self,
+                                       GBytes              *signed_data,
+                                       GVariant            *metadata,
+                                       GFile               *keyringdir,
+                                       GFile               *extra_keyring,
+                                       GCancellable        *cancellable,
+                                       GError             **error);
 
 gboolean
 _ostree_repo_commit_loose_final (OstreeRepo        *self,


### PR DESCRIPTION
Similar to c2b01ad.  For some reason I was thinking the commit data still needed to be written to disk prior to verifying, but it's just another artifact of spawning `gpgv2` (predates using GPGME).

Makes for a nice cleanup in `fetch_metadata_to_verify_delta_superblock()` as well.