### PR TITLE
use glibc's xattr support instead of requiring libattr.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AC_ARG_ENABLE(installed_tests,
               [enable_installed_tests=no])
 AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
 
-AC_CHECK_HEADER([attr/xattr.h],,[AC_MSG_ERROR([You must have attr/xattr.h from libattr])])
+AC_CHECK_HEADER([sys/xattr.h],,[AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 
 PKG_PROG_PKG_CONFIG
 

--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -23,7 +23,7 @@
 #include "config.h"
 
 #include <glib-unix.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <gio/gfiledescriptorbased.h>
 #include <gio/gunixoutputstream.h>
 #include "otutil.h"

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -34,7 +34,7 @@
 #include "ostree-checksum-input-stream.h"
 #include "ostree-mutable-tree.h"
 #include "ostree-varint.h"
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <glib/gprintf.h>
 
 gboolean

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -22,7 +22,7 @@
 
 #include "ot-fs-utils.h"
 #include "libgsystem.h"
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <gio/gunixinputstream.h>
 
 int


### PR DESCRIPTION
Fixes build on Debian,

Here's some details of the same problem in systemd:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=756097
http://cgit.freedesktop.org/systemd/systemd/commit/?id=d2edfae0f9b