### PR TITLE
test_rollsum needs -lz to link.

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -119,7 +119,7 @@ TESTS_LDADD = $(ostree_bin_shared_ldadd) $(OT_INTERNAL_GIO_UNIX_LIBS)
 
 tests_test_rollsum_SOURCES = src/libostree/ostree-rollsum.c tests/test-rollsum.c
 tests_test_rollsum_CFLAGS = $(TESTS_CFLAGS)
-tests_test_rollsum_LDADD = libbupsplit.la $(TESTS_LDADD)
+tests_test_rollsum_LDADD = libbupsplit.la $(TESTS_LDADD) $(OT_DEP_ZLIB_LIBS)
 
 tests_test_mutable_tree_CFLAGS = $(TESTS_CFLAGS)
 tests_test_mutable_tree_LDADD = $(TESTS_LDADD)


### PR DESCRIPTION
Test fails to link on Debian as it uses crc32, not sure what the best strategy is here.

    /usr/bin/ld: src/libostree/tests_test_rollsum-ostree-rollsum.o: undefined reference to symbol 'crc32'
    //lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
