### PR TITLE
build: Drop libattr from the spec file

### DIFF
--- a/packaging/ostree.spec.in
+++ b/packaging/ostree.spec.in
@@ -17,7 +17,6 @@ BuildRequires: pkgconfig(gio-unix-2.0)
 BuildRequires: pkgconfig(libsoup-2.4)
 BuildRequires: pkgconfig(libgsystem)
 BuildRequires: pkgconfig(e2p)
-BuildRequires: libattr-devel
 # Extras
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libselinux)


### PR DESCRIPTION
commit 534c4c20c3fa5ad9500ea96093a3ece7821a6056 already drops its
usage in the code.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>