### PR TITLE
giuseppe/auto summary

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -49,6 +49,7 @@ testfiles = test-basic \
 	test-setuid \
 	test-delta \
 	test-xattrs \
+	test-auto-summary \
 	$(NULL)
 insttest_SCRIPTS = $(addprefix tests/,$(testfiles:=.sh))
 

--- a/doc/ostree.repo-config.xml
+++ b/doc/ostree.repo-config.xml
@@ -85,6 +85,13 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><varname>commit-update-summary</varname></term>
+        <listitem><para>Boolean value controlling whether or not to
+        automatically update the summary file after a commit.  Defaults
+        to <literal>false</literal>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>fsync</varname></term>
         <listitem><para>Boolean value controlling whether or not to
         ensure files are on stable storage when performing operations

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -130,7 +130,7 @@ gboolean
 _ostree_repo_file_replace_contents (OstreeRepo    *self,
                                     int            dfd,
                                     const char    *path,
-                                    guint8        *buf,
+                                    const guint8  *buf,
                                     gsize          len,
                                     GCancellable  *cancellable,
                                     GError       **error);

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1509,7 +1509,7 @@ gboolean
 _ostree_repo_file_replace_contents (OstreeRepo    *self,
                                     int            dfd,
                                     const char    *path,
-                                    guint8        *buf,
+                                    const guint8   *buf,
                                     gsize          len,
                                     GCancellable  *cancellable,
                                     GError       **error)

--- a/tests/test-auto-summary.sh
+++ b/tests/test-auto-summary.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright (C) 2011 Colin Walters <walters@verbum.org>
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+echo "1..1"
+
+. $(dirname $0)/libtest.sh
+
+setup_test_repository "bare"
+echo "ok setup"
+
+mkdir test
+
+echo hello > test/a
+
+${CMD_PREFIX} $OSTREE commit -b test -s "A commit" test
+echo "ok commit 1"
+
+${CMD_PREFIX} $OSTREE summary --update
+
+OLD_MD5=$(md5sum repo/summary)
+
+echo hello2 > test/a
+
+${CMD_PREFIX} $OSTREE commit -b test -s "Another commit" test
+echo "ok commit 2"
+
+assert_streq $OLD_MD5 $(md5sum repo/summary)
+
+${CMD_PREFIX} $OSTREE --repo=repo config set core.commit-update-summary true
+
+echo hello3 > test/a
+
+${CMD_PREFIX} $OSTREE commit -b test -s "Another commit..." test
+echo "ok commit 3"
+
+assert_not_streq $OLD_MD5 $(md5sum repo/summary)


### PR DESCRIPTION
it adds a configuration flag in the config file to automatically update the summary file on a commit.

It won't interfere if we decide to add signatures to the summary file, as we can use the same signature used to sign the commit (and perhaps have a way to add signatures to an existing summary file)