### PR TITLE
 Teach fsck about partial commits

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -48,6 +48,7 @@ testfiles = test-basic \
 	test-admin-locking \
 	test-repo-checkout-subpath	\
 	test-reset-nonlinear \
+	test-oldstyle-partial \
 	test-setuid \
 	test-delta \
 	test-xattrs \

--- a/src/libostree/ostree-cmdprivate.c
+++ b/src/libostree/ostree-cmdprivate.c
@@ -21,6 +21,8 @@
 #include "config.h"
 
 #include "ostree-cmdprivate.h"
+#include "ostree-repo-private.h"
+#include "ostree-core-private.h"
 #include "ostree-sysroot.h"
 #include "ostree-bootloader-grub2.h"
 

--- a/src/libostree/ostree-core-private.h
+++ b/src/libostree/ostree-core-private.h
@@ -112,6 +112,12 @@ _ostree_get_relative_static_delta_part_path (const char        *from,
                                              const char        *to,
                                              guint              i);
 
+static inline char *
+_ostree_get_commitpartial_path (const char *checksum)
+{
+  return g_strconcat ("state/", checksum, ".commitpartial", NULL);
+}
+
 void
 _ostree_loose_path (char              *buf,
                     const char        *checksum,

--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -43,10 +43,16 @@ prune_commitpartial_file (OstreeRepo    *repo,
                           GError       **error)
 {
   gboolean ret = FALSE;
-  gs_unref_object GFile *objpath = ot_gfile_resolve_path_printf (repo->repodir, "state/%s.commitpartial", checksum);
+  g_autofree char *path = _ostree_get_commitpartial_path (checksum);
   
-  if (!ot_gfile_ensure_unlinked (objpath, cancellable, error))
-    goto out;
+  if (unlinkat (repo->repo_dir_fd, path, 0) != 0)
+    {
+      if (errno != ENOENT)
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+    }
 
   ret = TRUE;
  out:

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -167,22 +167,6 @@ suburi_new (SoupURI   *base,
 }
 
 static gboolean
-ensure_unlinked_at (int dfd,
-                    const char *path,
-                    GError **error)
-{
-  if (unlinkat (dfd, path, 0) != 0)
-    {
-      if (G_UNLIKELY (errno != ENOENT))
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
-    }
-  return TRUE;
-}
-
-static gboolean
 update_progress (gpointer user_data)
 {
   OtPullData *pull_data;
@@ -2196,7 +2180,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           const char *checksum = value;
           g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (checksum);
 
-          if (!ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
+          if (!ot_ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
             goto out;
         }
         g_hash_table_iter_init (&hash_iter, commits_to_fetch);
@@ -2205,7 +2189,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
             const char *commit = value;
             g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (commit);
 
-            if (!ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
+            if (!ot_ensure_unlinked_at (pull_data->repo->repo_dir_fd, commitpartial_path, 0))
               goto out;
           }
     }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -173,7 +173,7 @@ ensure_unlinked_at (int dfd,
 {
   if (unlinkat (dfd, path, 0) != 0)
     {
-      if (G_UNLIKELY (error != ENOENT))
+      if (G_UNLIKELY (errno != ENOENT))
         {
           glnx_set_error_from_errno (error);
           return FALSE;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1126,10 +1126,12 @@ scan_one_metadata_object_c (OtPullData         *pull_data,
       /* For commits, check whether we only had a partial fetch */
       if (!do_scan && objtype == OSTREE_OBJECT_TYPE_COMMIT)
         {
-          g_autofree char *commitpartial_path = _ostree_get_commitpartial_path (tmp_checksum);
-          struct stat stbuf;
+          OstreeRepoCommitState commitstate;
 
-          if (fstatat (pull_data->repo->repo_dir_fd, commitpartial_path, &stbuf, 0) == 0)
+          if (!ostree_repo_load_commit (pull_data->repo, tmp_checksum, NULL, &commitstate, error))
+            goto out;
+
+          if (commitstate & OSTREE_REPO_COMMIT_STATE_PARTIAL)
             {
               do_scan = TRUE;
               pull_data->commitpartial_exists = TRUE;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -280,6 +280,16 @@ gboolean      ostree_repo_load_variant_if_exists (OstreeRepo  *self,
                                                   GVariant     **out_variant,
                                                   GError       **error);
 
+typedef enum {
+  OSTREE_REPO_COMMIT_STATE_PARTIAL = (1 << 0),
+} OstreeRepoCommitState;
+
+gboolean      ostree_repo_load_commit (OstreeRepo            *self,
+                                       const char            *checksum, 
+                                       GVariant             **out_commit,
+                                       OstreeRepoCommitState *out_state,
+                                       GError               **error);
+
 gboolean ostree_repo_load_file (OstreeRepo         *self,
                                 const char         *checksum,
                                 GInputStream      **out_input,

--- a/src/libotutil/ot-fs-utils.c
+++ b/src/libotutil/ot-fs-utils.c
@@ -22,6 +22,7 @@
 
 #include "ot-fs-utils.h"
 #include "libgsystem.h"
+#include "libglnx.h"
 #include <sys/xattr.h>
 #include <gio/gunixinputstream.h>
 
@@ -188,3 +189,20 @@ ot_openat_read_stream (int             dfd,
  out:
   return ret;
 }
+
+gboolean
+ot_ensure_unlinked_at (int dfd,
+                       const char *path,
+                       GError **error)
+{
+  if (unlinkat (dfd, path, 0) != 0)
+    {
+      if (G_UNLIKELY (errno != ENOENT))
+        {
+          glnx_set_error_from_errno (error);
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+

--- a/src/libotutil/ot-fs-utils.h
+++ b/src/libotutil/ot-fs-utils.h
@@ -57,4 +57,8 @@ gboolean ot_openat_read_stream (int             dfd,
                                 GCancellable   *cancellable,
                                 GError        **error);
 
+gboolean ot_ensure_unlinked_at (int dfd,
+                                const char *path,
+                                GError **error);
+
 G_END_DECLS

--- a/tests/test-oldstyle-partial.sh
+++ b/tests/test-oldstyle-partial.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive-z2"
+
+echo '1..1'
+
+cd ${test_tmpdir}
+rm repo -rf
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
+
+ostree --repo=repo pull origin main --subpath /baz
+ostree fsck --repo=repo >fsck.out
+assert_file_has_content fsck.out 'Verifying content integrity of 0 commit objects'
+assert_file_has_content fsck.out '1 partial commits not verified'


### PR DESCRIPTION
An OSTree user noticed that `ostree fsck` would produce `missing
object` errors in the case of interrupted pulls.

It's possible to do e.g. `ostree pull --subpath=/usr/share/rpm ...`,
which gets you just that portion of the commit.  The use case for this
was being able to see what changes would appear in an update before
actually downloading all of it.

(I think this would be better covered by static deltas, but those
 aren't final yet, and `--subpath` predates it)

Further, `.commitpartial` is used as a successor to the `transaction`
symlink for more precise knowledge in the case where a pull was
interrupted that we needed to resume scanning.

So it makes sense for `ostree fsck` to be aware of it.