### PR TITLE
ostree_repo_checkout_tree_at: New API for checkouts

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -277,6 +277,7 @@ ostree_repo_write_commit_detached_metadata
 OstreeRepoCheckoutMode
 OstreeRepoCheckoutOverwriteMode
 ostree_repo_checkout_tree
+ostree_repo_checkout_tree_at
 ostree_repo_checkout_gc
 ostree_repo_read_commit
 OstreeRepoListObjectsFlags

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -449,6 +449,36 @@ ostree_repo_checkout_tree (OstreeRepo               *self,
                            GCancellable             *cancellable,
                            GError                  **error);
 
+/**
+ * OstreeRepoCheckoutOptions:
+ * @OSTREE_REPO_CHECKOUT_OPTIONS_NONE: No special options
+ * @OSTREE_REPO_CHECKOUT_OPTIONS_CACHE: Make use of the uncompressed objects cache for archive type repositories
+ *
+ * An extensible options structure controlling checkout.  Ensure that
+ * you have entirely zeroed the structure, then set just the desired
+ * options.
+ */
+typedef struct {
+  OstreeRepoCheckoutMode mode;
+  OstreeRepoCheckoutOverwriteMode overwrite_mode;
+  
+  guint enable_uncompressed_cache : 1;
+  guint unused : 31;
+
+  const char *subpath;
+
+  guint unused_uints[6];
+  gpointer unused_ptrs[8];
+} OstreeRepoCheckoutOptions;
+
+gboolean ostree_repo_checkout_tree_at (OstreeRepo                         *self,
+                                       OstreeRepoCheckoutOptions          *options,
+                                       int                                 destination_dfd,
+                                       const char                         *destination_path,
+                                       const char                         *commit,
+                                       GCancellable                       *cancellable,
+                                       GError                            **error);
+
 gboolean       ostree_repo_checkout_gc (OstreeRepo        *self,
                                         GCancellable      *cancellable,
                                         GError           **error);

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -451,12 +451,12 @@ ostree_repo_checkout_tree (OstreeRepo               *self,
 
 /**
  * OstreeRepoCheckoutOptions:
- * @OSTREE_REPO_CHECKOUT_OPTIONS_NONE: No special options
- * @OSTREE_REPO_CHECKOUT_OPTIONS_CACHE: Make use of the uncompressed objects cache for archive type repositories
  *
  * An extensible options structure controlling checkout.  Ensure that
  * you have entirely zeroed the structure, then set just the desired
- * options.
+ * options.  This is used by ostree_repo_checkout_tree_at() which
+ * supercedes previous separate enumeration usage in
+ * ostree_repo_checkout_tree().
  */
 typedef struct {
   OstreeRepoCheckoutMode mode;

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-echo "1..47"
+echo "1..48"
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"
@@ -361,6 +361,25 @@ if $OSTREE commit -b test2 -s "Attempt to commit a FIFO" 2>../errmsg; then
     assert_file_has_content ../errmsg "Unsupported file type"
 fi
 echo "ok commit of fifo was rejected"
+
+cd ${test_tmpdir}
+rm repo2 -rf
+mkdir repo2
+${CMD_PREFIX} ostree --repo=repo2 init --mode=archive-z2
+${CMD_PREFIX} ostree --repo=repo2 pull-local repo
+rm -rf test2-checkout
+${CMD_PREFIX} ostree --repo=repo2 checkout -U --disable-cache test2 test2-checkout
+if test -d repo2/uncompressed-objects-cache; then
+    ls repo2/uncompressed-objects-cache > ls.txt
+    if test -s ls.txt; then
+	assert_not_reached "repo has uncompressed objects"
+    fi
+fi
+rm test2-checkout -rf
+${CMD_PREFIX} ostree --repo=repo2 checkout -U test2 test2-checkout
+assert_file_has_content test2-checkout/baz/cow moo
+assert_has_dir repo2/uncompressed-objects-cache
+echo "ok disable cache checkout"
 
 cd ${test_tmpdir}
 rm -rf test2-checkout


### PR DESCRIPTION
rpm-ostree currently uses ostree_repo_checkout_tree(), which as a side
effect will use the uncompressed objects cache by default.  This is
rather annoying if you're using rpm-ostree on a server-side
repository, because if you then rsync the repo, you'll be syncing out
the uncompressed objects unless you exclude them.

We added the ability to disable the uncompressed cache in the
repository config to fix this, but it's better to allow application
control over this.  The uncompressed cache will in some future version
become opt in as well.

This new API further:
 - Drops the `GFile` usage in favor of `openat` APIs
 - Improves ergonomics by avoiding callers having to query the source
   `GFileInfo` (and carry around a copy of `OSTREE_GIO_FAST_QUERYINFO`)
 - Has a more extensible options structure

Per the comment, I rather crudely have the `ostree checkout` builtin
call both APIs to ensure some testing coverage.

However, I'd like to in the future have easier-to-set-up testing code
that calls `libtest.sh` to set up dummy data.