### PR TITLE
reset: Don't enforce parent commits

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -46,6 +46,7 @@ testfiles = test-basic \
 	test-admin-instutil-set-kargs \
 	test-admin-upgrade-not-backwards \
 	test-repo-checkout-subpath	\
+	test-reset-nonlinear \
 	test-setuid \
 	test-delta \
 	test-xattrs \

--- a/tests/test-reset-nonlinear.sh
+++ b/tests/test-reset-nonlinear.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+echo "1..1"
+
+. $(dirname $0)/libtest.sh
+
+setup_test_repository "archive-z2"
+cd ${test_tmpdir}/files
+$OSTREE commit -b testx -s "Another Commit"
+cd ${test_tmpdir}
+$OSTREE reset test2 testx
+
+echo "ok reset nonlinear"


### PR DESCRIPTION
First, git doesn't do this, and whatever Linus thinks is right or
something.

Second specifically to OSTree, it's quite common to not have
intermediate commits.  If one wants to reset a ref in order to prune
data after a deployment, the parentage check will fail.