### PR TITLE
Add an OstreeRepo signal for printing GPG status during pulls

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -231,6 +231,7 @@ OstreeRepoRemoteChange
 ostree_repo_remote_change
 ostree_repo_remote_list
 ostree_repo_remote_get_url
+ostree_repo_remote_get_gpg_verify
 ostree_repo_get_parent
 ostree_repo_write_config
 OstreeRepoTransactionStats

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1696,9 +1696,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     {
       pull_data->remote_name = g_strdup (remote_name_or_baseurl);
 
-      if (!_ostree_repo_get_remote_boolean_option (self,
-                                                   remote_name_or_baseurl, "gpg-verify",
-                                                   TRUE, &pull_data->gpg_verify, error))
+      if (!ostree_repo_remote_get_gpg_verify (self, remote_name_or_baseurl,
+                                              &pull_data->gpg_verify, error))
         goto out;
     }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -76,6 +76,10 @@
  */
 typedef struct {
   GObjectClass parent_class;
+
+  void (*gpg_verify_result) (OstreeRepo *self,
+                             const char *checksum,
+                             OstreeGpgVerifyResult *result);
 } OstreeRepoClass;
 
 enum {
@@ -83,6 +87,13 @@ enum {
 
   PROP_PATH
 };
+
+enum {
+  GPG_VERIFY_RESULT,
+  LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0 };
 
 G_DEFINE_TYPE (OstreeRepo, ostree_repo, G_TYPE_OBJECT)
 
@@ -471,6 +482,25 @@ ostree_repo_class_init (OstreeRepoClass *klass)
                                                         "",
                                                         G_TYPE_FILE,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+  /**
+   * OstreeRepo::gpg-verify-result:
+   * @self: an #OstreeRepo
+   * @checksum: checksum of the signed object
+   * @result: an #OstreeGpgVerifyResult
+   *
+   * Emitted during a pull operation upon GPG verification (if enabled).
+   * Applications can connect to this signal to output the verification
+   * results if desired.
+   */
+  signals[GPG_VERIFY_RESULT] = g_signal_new ("gpg-verify-result",
+                                             OSTREE_TYPE_REPO,
+                                             G_SIGNAL_RUN_LAST,
+                                             G_STRUCT_OFFSET (OstreeRepoClass, gpg_verify_result),
+                                             NULL, NULL, NULL,
+                                             G_TYPE_NONE, 2,
+                                             G_TYPE_STRING,
+                                             OSTREE_TYPE_GPG_VERIFY_RESULT);
 }
 
 static void

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -34,6 +34,9 @@
 #include "ostree-repo-file-enumerator.h"
 #include "ostree-gpg-verifier.h"
 
+/* XXX Only for _ostree_gpg_error_to_gio_error().  Move it elsewhere? */
+#include "ostree-gpg-verify-result-private.h"
+
 #include <locale.h>
 #include <gpgme.h>
 #include <glib/gstdio.h>
@@ -3004,8 +3007,8 @@ sign_data (OstreeRepo     *self,
   
   if ((err = gpgme_new (&context)) != GPG_ERR_NO_ERROR)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Unable to create gpg context");
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Unable to create gpg context: ");
       goto out;
     }
 
@@ -3014,8 +3017,8 @@ sign_data (OstreeRepo     *self,
   if ((err = gpgme_set_protocol (context, GPGME_PROTOCOL_OpenPGP)) !=
       GPG_ERR_NO_ERROR)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Unable to set gpg protocol");
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Unable to set gpg protocol: ");
       goto out;
     }
   
@@ -3024,27 +3027,34 @@ sign_data (OstreeRepo     *self,
       if ((err = gpgme_ctx_set_engine_info (context, info->protocol, NULL, homedir))
           != GPG_ERR_NO_ERROR)
         {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Unable to set gpg homedir to '%s'",
-                       homedir);
+          _ostree_gpg_error_to_gio_error (err, error);
+          g_prefix_error (error, "Unable to set gpg homedir to '%s': ",
+                          homedir);
           goto out;
         }
     }
 
   /* Get the secret keys with the given key id */
-  if ((err = gpgme_get_key (context, key_id, &key, 1)) != GPG_ERR_NO_ERROR)
+  err = gpgme_get_key (context, key_id, &key, 1);
+  if (gpgme_err_code (err) == GPG_ERR_EOF)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "No gpg key found with ID %s (homedir: %s)", key_id,
                    homedir ? homedir : "<default>");
       goto out;
     }
+  else if (err != GPG_ERR_NO_ERROR)
+    {
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Unable to lookup key ID %s: ", key_id);
+      goto out;
+    }
   
   /* Add the key to the context as a signer */
   if ((err = gpgme_signers_add (context, key)) != GPG_ERR_NO_ERROR)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Error signing commit");
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Error signing commit: ");
       goto out;
     }
   
@@ -3053,8 +3063,8 @@ sign_data (OstreeRepo     *self,
     const char *buf = g_bytes_get_data (input_data, &len);
     if ((err = gpgme_data_new_from_mem (&commit_buffer, buf, len, FALSE)) != GPG_ERR_NO_ERROR)
       {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to create buffer from commit file");
+        _ostree_gpg_error_to_gio_error (err, error);
+        g_prefix_error (error, "Failed to create buffer from commit file: ");
         goto out;
       }
   }
@@ -3069,16 +3079,16 @@ sign_data (OstreeRepo     *self,
   
   if ((err = gpgme_data_new_from_fd (&signature_buffer, signature_fd)) != GPG_ERR_NO_ERROR)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Failed to create buffer for signature file");
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Failed to create buffer for signature file: ");
       goto out;
     }
   
   if ((err = gpgme_op_sign (context, commit_buffer, signature_buffer, GPGME_SIG_MODE_DETACH))
       != GPG_ERR_NO_ERROR)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Failure signing commit file");
+      _ostree_gpg_error_to_gio_error (err, error);
+      g_prefix_error (error, "Failure signing commit file: ");
       goto out;
     }
   

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -492,6 +492,10 @@ ostree_repo_class_init (OstreeRepoClass *klass)
    * Emitted during a pull operation upon GPG verification (if enabled).
    * Applications can connect to this signal to output the verification
    * results if desired.
+   *
+   * The signal will be emitted from whichever #GMainContext is the
+   * thread-default at the point when ostree_repo_pull_with_options()
+   * is called.
    */
   signals[GPG_VERIFY_RESULT] = g_signal_new ("gpg-verify-result",
                                              OSTREE_TYPE_REPO,

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1067,6 +1067,29 @@ ostree_repo_remote_get_url (OstreeRepo  *self,
   return ret;
 }
 
+/**
+ * ostree_repo_remote_get_gpg_verify:
+ * @self: Repo
+ * @name: Name of remote
+ * @out_gpg_verify: (out) (allow-none): Remote's GPG option
+ * @error: Error
+ *
+ * Return whether GPG verification is enabled for the remote named @name
+ * through @out_gpg_verify.  It is an error if the provided remote does
+ * not exist.
+ *
+ * Returns: %TRUE on success, %FALSE on failure
+ */
+gboolean
+ostree_repo_remote_get_gpg_verify (OstreeRepo  *self,
+                                   const char  *name,
+                                   gboolean    *out_gpg_verify,
+                                   GError     **error)
+{
+  return _ostree_repo_get_remote_boolean_option (self, name, "gpg-verify",
+                                                 TRUE, out_gpg_verify, error);
+}
+
 static gboolean
 ostree_repo_mode_to_string (OstreeRepoMode   mode,
                             const char     **out_mode,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -107,6 +107,11 @@ gboolean      ostree_repo_remote_get_url (OstreeRepo   *self,
                                           char        **out_url,
                                           GError      **error);
 
+gboolean      ostree_repo_remote_get_gpg_verify (OstreeRepo  *self,
+                                                 const char  *name,
+                                                 gboolean    *out_gpg_verify,
+                                                 GError     **error);
+
 OstreeRepo * ostree_repo_get_parent (OstreeRepo  *self);
 
 gboolean      ostree_repo_write_config (OstreeRepo *self,

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -385,3 +385,27 @@ ostree_ensure_repo_writable (OstreeRepo *repo,
 
   return ret;
 }
+
+void
+ostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
+{
+  GString *buffer;
+  guint n_sigs, ii;
+
+  n_sigs = ostree_gpg_verify_result_count_all (result);
+
+  /* XXX If we ever add internationalization, use ngettext() here. */
+  g_print ("Found %u signature%s:\n", n_sigs, n_sigs == 1 ? "" : "s");
+
+  buffer = g_string_sized_new (256);
+
+  for (ii = 0; ii < n_sigs; ii++)
+    {
+      g_string_append_c (buffer, '\n');
+      ostree_gpg_verify_result_describe (result, ii, buffer, "  ",
+                                         OSTREE_GPG_SIGNATURE_FORMAT_DEFAULT);
+    }
+
+  g_print ("%s", buffer->str);
+  g_string_free (buffer, TRUE);
+}

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -59,3 +59,5 @@ gboolean ostree_admin_option_context_parse (GOptionContext *context,
                                             GCancellable *cancellable, GError **error);
 
 gboolean ostree_ensure_repo_writable (OstreeRepo *repo, GError **error);
+
+void ostree_print_gpg_verify_result (OstreeGpgVerifyResult *result);


### PR DESCRIPTION
As discussed in https://github.com/projectatomic/rpm-ostree/pull/126.

The first commit is just some related cleanup work I had laying around.

Also, since I'm rewriting the logic again, shouldn't GPG verification on pulls fail if *any* signatures are bad?  I've preserved the old logic which is satisfied merely by one *good* signature, but it seems wrong to me.