### PR TITLE
deploy: Use syncfs() on /, /boot instead of sync()

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -874,99 +874,106 @@ ostree_sysroot_write_origin_file (OstreeSysroot         *sysroot,
 }
 
 static gboolean
-get_kernel_from_tree (GFile         *deployroot,
-                      GFile        **out_kernel,
-                      GFile        **out_initramfs,
-                      GCancellable  *cancellable,
-                      GError       **error)
+get_kernel_from_tree (int             deployment_dfd,
+                      int            *out_kernel_fd,
+                      int            *out_initramfs_fd,
+                      GCancellable   *cancellable,
+                      GError        **error)
 {
   gboolean ret = FALSE;
-  gs_unref_object GFile *ostree_bootdir
-    = g_file_resolve_relative_path (deployroot, "usr/lib/ostree-boot");
-  gs_unref_object GFile *bootdir = g_file_get_child (deployroot, "boot");
-  gs_unref_object GFileEnumerator *dir_enum = NULL;
-  gs_unref_object GFile *ret_kernel = NULL;
-  gs_unref_object GFile *ret_initramfs = NULL;
+  struct stat stbuf;
+  glnx_fd_close int boot_dfd = -1;
+  g_auto(GLnxDirFdIterator) dfditer = { 0, };
+  glnx_fd_close int ret_kernel_fd = -1;
+  glnx_fd_close int ret_initramfs_fd = -1;
   gs_free char *kernel_checksum = NULL;
   gs_free char *initramfs_checksum = NULL;
 
-  if (g_file_query_exists (ostree_bootdir, NULL))
+  boot_dfd = glnx_opendirat_with_errno (deployment_dfd, "usr/lib/ostree-boot");
+  if (boot_dfd == -1)
     {
-      dir_enum = g_file_enumerate_children (ostree_bootdir, OSTREE_GIO_FAST_QUERYINFO,
-                                            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                                            NULL, error);
-      if (!dir_enum)
-        goto out;
+      if (errno != ENOENT)
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+      else
+        {
+          if (!glnx_opendirat (deployment_dfd, "boot", TRUE, &boot_dfd, error))
+            goto out;
+        }
     }
-  else
-    {
-      dir_enum = g_file_enumerate_children (bootdir, OSTREE_GIO_FAST_QUERYINFO,
-                                            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                                            NULL, error);
-      if (!dir_enum)
-        goto out;
-    }
+
+  if (!glnx_dirfd_iterator_init_take_fd (boot_dfd, &dfditer, error))
+    goto out;
+  boot_dfd = -1; /* Transfer ownership */
 
   while (TRUE)
     {
-      GFileInfo *file_info = NULL;
-      const char *name;
+      struct dirent *dent;
 
-      if (!gs_file_enumerator_iterate (dir_enum, &file_info, NULL,
-                                       cancellable, error))
+      if (!glnx_dirfd_iterator_next_dent (&dfditer, &dent, cancellable, error))
         goto out;
-      if (file_info == NULL)
+          
+      if (dent == NULL)
         break;
 
-      name = g_file_info_get_name (file_info);
-      
-      if (ret_kernel == NULL && g_str_has_prefix (name, "vmlinuz-"))
+      if (ret_kernel_fd == -1 && g_str_has_prefix (dent->d_name, "vmlinuz-"))
         {
-          const char *dash = strrchr (name, '-');
+          const char *dash = strrchr (dent->d_name, '-');
           g_assert (dash);
           if (ostree_validate_structureof_checksum_string (dash + 1, NULL))
             {
               kernel_checksum = g_strdup (dash + 1);
-              ret_kernel = g_file_enumerator_get_child (dir_enum, file_info);
+              ret_kernel_fd = openat (dfditer.fd, dent->d_name, O_RDONLY);
+              if (ret_kernel_fd == -1)
+                {
+                  glnx_set_error_from_errno (error);
+                  goto out;
+                }
             }
         }
-      else if (ret_initramfs == NULL && g_str_has_prefix (name, "initramfs-"))
+      else if (ret_initramfs_fd == -1 && g_str_has_prefix (name, "initramfs-"))
         {
-          const char *dash = strrchr (name, '-');
+          const char *dash = strrchr (dent->d_name, '-');
           g_assert (dash);
           if (ostree_validate_structureof_checksum_string (dash + 1, NULL))
             {
               initramfs_checksum = g_strdup (dash + 1);
-              ret_initramfs = g_file_enumerator_get_child (dir_enum, file_info);
+              ret_initramfs_fd = openat (dfditer.fd, dent->d_name, O_RDONLY);
+              if (ret_initramfs_fd == -1)
+                {
+                  glnx_set_error_from_errno (error);
+                  goto out;
+                }
             }
         }
       
-      if (ret_kernel && ret_initramfs)
+      if (ret_kernel_fd != -1 && ret_initramfs_fd != -1)
         break;
     }
 
-  if (ret_kernel == NULL)
+  if (ret_kernel_fd == -1)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                   "Failed to find boot/vmlinuz-<CHECKSUM> in %s",
-                   gs_file_get_path_cached (deployroot));
+                   "Failed to find boot/vmlinuz-<CHECKSUM> in tree");
       goto out;
     }
 
-  if (ret_initramfs != NULL)
+  if (ret_initramfs_fd != -1)
     {
       if (strcmp (kernel_checksum, initramfs_checksum) != 0)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
-                       "Mismatched kernel %s checksum vs initrd %s",
-                       gs_file_get_basename_cached (ret_initramfs),
-                       gs_file_get_basename_cached (ret_initramfs));
+                       "Mismatched kernel checksum vs initrd in tree");
           goto out;
         }
     }
 
-  ot_transfer_out_value (out_kernel, &ret_kernel);
-  ot_transfer_out_value (out_initramfs, &ret_initramfs);
+  *out_kernel_fd = ret_kernel_fd;
+  ret_kernel_fd = -1;
+  *out_initramfs_fd = ret_initramfs_fd;
+  ret_initramfs_fd = -1;
   ret = TRUE;
  out:
   return ret;
@@ -1174,16 +1181,18 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   const char *osname = ostree_deployment_get_osname (deployment);
   const char *bootcsum = ostree_deployment_get_bootcsum (deployment);
   gs_unref_object GFile *bootdir = NULL;
-  gs_unref_object GFile *bootcsumdir = NULL;
-  gs_unref_object GFile *bootconfpath = NULL;
+  g_autofree char *bootcsumdir = NULL;
+  g_autofree char *bootconfdir = NULL;
+  g_autofree char *bootconf_name = NULL;
   gs_unref_object GFile *bootconfpath_parent = NULL;
   gs_free char *dest_kernel_name = NULL;
   gs_unref_object GFile *dest_kernel_path = NULL;
   gs_unref_object GFile *dest_initramfs_path = NULL;
-  gs_unref_object GFile *tree_kernel_path = NULL;
-  gs_unref_object GFile *tree_initramfs_path = NULL;
-  gs_unref_object GFile *deployment_dir = NULL;
+  g_autofree char *tree_kernel_path = NULL;
+  g_autofree char *tree_initramfs_path = NULL;
+  g_autofree char *deployment_dirpath = NULL;
   glnx_fd_close int deployment_dfd = -1;
+  glnx_fd_close int boot_dfd = -1;
   gs_free char *contents = NULL;
   gs_free char *deployment_version = NULL;
   gs_unref_hashtable GHashTable *osrelease_values = NULL;
@@ -1200,28 +1209,29 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
   OstreeBootconfigParser *bootconfig;
 
   bootconfig = ostree_deployment_get_bootconfig (deployment);
-  deployment_dir = ostree_sysroot_get_deployment_directory (sysroot, deployment);
+  deployment_dirpath = ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
 
   if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (deployment_dir), FALSE,
                        &deployment_dfd, error))
     goto out;
 
-  if (!get_kernel_from_tree (deployment_dir, &tree_kernel_path, &tree_initramfs_path,
+  if (!get_kernel_from_tree (deployment_dfd,
+                             &kernel_fd, &initramfs_fd,
                              cancellable, error))
     goto out;
 
-  bootdir = g_file_get_child (ostree_sysroot_get_path (sysroot), "boot");
-  bootcsumdir = ot_gfile_resolve_path_printf (bootdir, "ostree/%s-%s",
-                                              osname,
-                                              bootcsum);
-  bootconfpath = ot_gfile_resolve_path_printf (bootdir, "loader.%d/entries/ostree-%s-%d.conf",
-                                               new_bootversion, osname, 
-                                               ostree_deployment_get_index (deployment));
-
-  if (!ot_util_ensure_directory_and_fsync (bootcsumdir, cancellable, error))
+  if (!glnx_opendirat (sysroot->sysroot_fd, "boot", TRUE, &boot_dfd, error))
     goto out;
-  bootconfpath_parent = g_file_get_parent (bootconfpath);
-  if (!ot_util_ensure_directory_and_fsync (bootconfpath_parent, cancellable, error))
+
+  bootcsumdir = g_strdup_printf ("ostree/%s-%s", osname, bootcsum);
+  bootconfdir = g_strdup_printf ("loader.%d/entries", new_bootversion);
+  bootconf_name = g_strdup_printf ("ostree-%s-%d.conf", osname, 
+                                   ostree_deployment_get_index (deployment));
+
+  if (!glnx_shutil_mkdir_p_at (self->sysroot_fd, bootcsumdir, 0775, cancellable, error))
+    goto out;
+
+  if (!glnx_shutil_mkdir_p_at (boot_dfd, bootconfdir, 0775, cancellable, error))
     goto out;
 
   dest_kernel_name = remove_checksum_from_kernel_name (gs_file_get_basename_cached (tree_kernel_path),

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -43,8 +43,6 @@ struct OstreeSysroot {
 
   /* Only access through ostree_sysroot_get_repo() */
   OstreeRepo *repo;
-
-  gboolean did_relabel_var;
 };
 
 gboolean

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -43,6 +43,8 @@ struct OstreeSysroot {
 
   /* Only access through ostree_sysroot_get_repo() */
   OstreeRepo *repo;
+
+  gboolean did_relabel_var;
 };
 
 gboolean

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -66,6 +66,8 @@ ostree_sysroot_finalize (GObject *object)
   g_clear_object (&self->sepolicy);
   g_clear_object (&self->repo);
 
+  (void) close (self->sysroot_fd);
+
   G_OBJECT_CLASS (ostree_sysroot_parent_class)->finalize (object);
 }
 


### PR DESCRIPTION
This way we will actually catch errors, and we also avoid flushing
unrelated mount points.

I believe this change to be safe; OSTree only touches the `/` mount
point which covers the repository, the deployment roots (including
their copy of `/etc`), as well as `/boot`.  On initial system installs
we do relabel `/var` but that shouldn't happen at ostree time - any
new directories are taken care of via `systemd-tmpfiles` on boot.