### PR TITLE
sysroot: Add ostree_sysroot_get_fd()

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -364,6 +364,7 @@ ostree_sysroot_new
 ostree_sysroot_new_default
 ostree_sysroot_get_path
 ostree_sysroot_load
+ostree_sysroot_get_fd
 ostree_sysroot_ensure_initialized
 ostree_sysroot_get_bootversion
 ostree_sysroot_get_subbootversion

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -192,6 +192,23 @@ ensure_sysroot_fd (OstreeSysroot          *self,
 }
 
 /**
+ * ostree_sysroot_get_fd:
+ * @self: Sysroot
+ *
+ * Access a file descriptor that refers to the root directory of this
+ * sysroot.  ostree_sysroot_load() must have been invoked prior to
+ * calling this function.
+ * 
+ * Returns: A file descriptor valid for the lifetime of @self
+ */
+int
+ostree_sysroot_get_fd (OstreeSysroot *self)
+{
+  g_return_val_if_fail (self->sysroot_fd != -1, -1);
+  return self->sysroot_fd;
+}
+
+/**
  * ostree_sysroot_ensure_initialized:
  * @self: Sysroot
  * @cancellable: Cancellable

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -39,6 +39,8 @@ OstreeSysroot* ostree_sysroot_new_default (void);
 
 GFile *ostree_sysroot_get_path (OstreeSysroot *self);
 
+int ostree_sysroot_get_fd (OstreeSysroot *self);
+
 gboolean ostree_sysroot_load (OstreeSysroot  *self,
                               GCancellable   *cancellable,
                               GError        **error);


### PR DESCRIPTION
This way external programs like rpm-ostree can do fd-relative
operations on the deployment directories, like inspecting the RPM
database.