### PR TITLE
sysroot: Cache an OstreeRepo instance

### DIFF
--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -40,6 +40,9 @@ struct OstreeSysroot {
   int bootversion;
   int subbootversion;
   OstreeDeployment *booted_deployment;
+
+  /* Only access through ostree_sysroot_get_repo() */
+  OstreeRepo *repo;
 };
 
 gboolean

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -64,6 +64,7 @@ ostree_sysroot_finalize (GObject *object)
 
   g_clear_object (&self->path);
   g_clear_object (&self->sepolicy);
+  g_clear_object (&self->repo);
 
   G_OBJECT_CLASS (ostree_sysroot_parent_class)->finalize (object);
 }
@@ -111,8 +112,12 @@ static void
 ostree_sysroot_constructed (GObject *object)
 {
   OstreeSysroot *self = OSTREE_SYSROOT (object);
+  gs_unref_object GFile *repo_path = NULL;
 
   g_assert (self->path != NULL);
+
+  repo_path = g_file_resolve_relative_path (self->path, "ostree/repo");
+  self->repo = ostree_repo_new (repo_path);
 
   G_OBJECT_CLASS (ostree_sysroot_parent_class)->constructed (object);
 }
@@ -875,15 +880,15 @@ ostree_sysroot_get_repo (OstreeSysroot         *self,
                          GError       **error)
 {
   gboolean ret = FALSE;
-  gs_unref_object OstreeRepo *ret_repo = NULL;
-  gs_unref_object GFile *repo_path = g_file_resolve_relative_path (self->path, "ostree/repo");
 
-  ret_repo = ostree_repo_new (repo_path);
-  if (!ostree_repo_open (ret_repo, cancellable, error))
+  if (!ostree_repo_open (self->repo, cancellable, error))
     goto out;
-    
+
+  if (out_repo != NULL)
+    *out_repo = g_object_ref (self->repo);
+
   ret = TRUE;
-  ot_transfer_out_value (out_repo, &ret_repo);
+
  out:
   return ret;
 }


### PR DESCRIPTION
Rather than returning a new `OstreeRepo` instance in each call to `ostree_sysroot_get_repo()`, cache one internally so the same instance is returned each time.

Need this to make https://github.com/projectatomic/rpm-ostree/pull/126 work.

Semantic changes like this tend to invite unforeseen side-effects, but as best as I can tell this seems okay.  Test cases pass and I can now see GPG status during `rpm-ostree upgrade`.