### PR TITLE
Update the help for 'ostree reset'

### DIFF
--- a/src/ostree/ot-builtin-reset.c
+++ b/src/ostree/ot-builtin-reset.c
@@ -63,7 +63,7 @@ ostree_builtin_reset (int           argc,
   gs_free gchar *current = NULL;
   gs_free gchar *checksum = NULL;
 
-  context = g_option_context_new ("[ARG] - Reset a ref to a previous commit");
+  context = g_option_context_new ("REF COMMIT - Reset a REF to a previous COMMIT");
 
   if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
     goto out;
@@ -73,7 +73,7 @@ ostree_builtin_reset (int           argc,
 
   if (argc <= 2)
     {
-      ot_util_usage_error (context, "A ref and commit argument is required", error);
+      ot_util_usage_error (context, "A REF and COMMIT argument is required", error);
       goto out;
     }
   ref = argv[1];


### PR DESCRIPTION
As of `ostree` 2015.6, the help for the `reset` command does not state that it requires a REF and a COMMIT as arguments (even though the error message will tell you that).

This just makes the help a bit more useful in that regard.

