### PR TITLE
g_output_stream_splice: check correctly the error code

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -1344,10 +1344,13 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
       part_payload_out = (GMemoryOutputStream*)g_memory_output_stream_new (NULL, 0, g_realloc, g_free);
       part_payload_compressor = (GConverterOutputStream*)g_converter_output_stream_new ((GOutputStream*)part_payload_out, compressor);
 
-      if (0 > g_output_stream_splice ((GOutputStream*)part_payload_compressor, part_payload_in,
-                                      G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET | G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
-                                      cancellable, error))
-        goto out;
+      {
+        gssize n_bytes_written = g_output_stream_splice ((GOutputStream*)part_payload_compressor, part_payload_in,
+                                                         G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET | G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
+                                                         cancellable, error);
+        if (n_bytes_written < 0)
+          goto out;
+      }
 
       /* FIXME - avoid duplicating memory here */
       delta_part = g_variant_new ("(y@ay)",

--- a/src/libostree/ostree-repo-static-delta-processing.c
+++ b/src/libostree/ostree-repo-static-delta-processing.c
@@ -294,11 +294,14 @@ decompress_all (GConverter   *converter,
   gs_unref_object GMemoryOutputStream *memout = (GMemoryOutputStream*)g_memory_output_stream_new (NULL, 0, g_realloc, g_free);
   gs_unref_object GInputStream *convin = g_converter_input_stream_new ((GInputStream*)memin, converter);
 
-  if (0 > g_output_stream_splice ((GOutputStream*)memout, convin,
-                                  G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
-                                  G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
-                                  cancellable, error))
-    goto out;
+  {
+    gssize n_bytes_written = g_output_stream_splice ((GOutputStream*)memout, convin,
+                                                     G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
+                                                     G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+                                                     cancellable, error);
+      if (n_bytes_written < 0)
+        goto out;
+  }
 
   ret = TRUE;
   *out_uncompressed = g_memory_output_stream_steal_as_bytes (memout);

--- a/src/ostree/ot-builtin-cat.c
+++ b/src/ostree/ot-builtin-cat.c
@@ -46,9 +46,12 @@ cat_one_file (GFile         *f,
   if (!in)
     goto out;
 
-  if (!g_output_stream_splice (stdout_stream, in, G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
-                               cancellable, error))
-    goto out;
+  {
+    gssize n_bytes_written = g_output_stream_splice (stdout_stream, in, G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE,
+                                                     cancellable, error);
+    if (n_bytes_written < 0)
+      goto out;
+  }
 
   ret = TRUE;
  out:


### PR DESCRIPTION
Check that the error code < 0 as 0 is a success status.

The occurrences in ostree-repo-static-delta-*.c should never happen,
but change for completeness.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>