### PR TITLE
repo: Stop creating "transaction" symlink

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1048,7 +1048,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
 
   g_return_val_if_fail (self->in_transaction == FALSE, FALSE);
 
-  /* We used to create a `transaction` symbolic link, but it's not
+  /* We used to create a `transaction` symbolic link, but it's now
    * obsoleted by the per-commit .commitpartial files.  We no longer
    * create it, but let's still read it if it exists, as well as
    * unlink it when we're done.
@@ -1056,7 +1056,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
   if (fstatat (self->repo_dir_fd, "transaction", &stbuf, AT_SYMLINK_NOFOLLOW) != 0)
     {
       if (errno == ENOENT)
-        ret_transaction_resume = TRUE;
+        ret_transaction_resume = FALSE;
       else
         {
           glnx_set_error_from_errno (error);
@@ -1064,7 +1064,7 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
         }
     }
   else 
-    ret_transaction_resume = FALSE;
+    ret_transaction_resume = TRUE;
 
   memset (&self->txn_stats, 0, sizeof (OstreeRepoTransactionStats));
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1044,26 +1044,31 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
 {
   gboolean ret = FALSE;
   gboolean ret_transaction_resume = FALSE;
-  gs_free char *transaction_str = NULL;
+  struct stat stbuf;
 
   g_return_val_if_fail (self->in_transaction == FALSE, FALSE);
 
-  if (self->transaction_lock_path == NULL)
-    self->transaction_lock_path = g_file_resolve_relative_path (self->repodir, "transaction");
-
-  if (g_file_query_file_type (self->transaction_lock_path, G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL) == G_FILE_TYPE_SYMBOLIC_LINK)
-    ret_transaction_resume = TRUE;
-  else
+  /* We used to create a `transaction` symbolic link, but it's not
+   * obsoleted by the per-commit .commitpartial files.  We no longer
+   * create it, but let's still read it if it exists, as well as
+   * unlink it when we're done.
+   */
+  if (fstatat (self->repo_dir_fd, "transaction", &stbuf, AT_SYMLINK_NOFOLLOW) != 0)
+    {
+      if (errno == ENOENT)
+        ret_transaction_resume = TRUE;
+      else
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+    }
+  else 
     ret_transaction_resume = FALSE;
 
   memset (&self->txn_stats, 0, sizeof (OstreeRepoTransactionStats));
 
   self->in_transaction = TRUE;
-  if (ret_transaction_resume)
-    {
-      if (!ot_gfile_ensure_unlinked (self->transaction_lock_path, cancellable, error))
-        goto out;
-    }
 
   self->commit_stagedir_name = g_strconcat ("tmpobjects-", self->boot_id, NULL);
   if (mkdirat (self->tmp_dir_fd, self->commit_stagedir_name, 0777) == -1)
@@ -1080,11 +1085,6 @@ ostree_repo_prepare_transaction (OstreeRepo     *self,
                      &self->commit_stagedir_fd, error))
     goto out;
   
-  transaction_str = g_strdup_printf ("pid=%llu", (unsigned long long) getpid ());
-  if (!g_file_make_symbolic_link (self->transaction_lock_path, transaction_str,
-                                  cancellable, error))
-    goto out;
-
   ret = TRUE;
   if (out_transaction_resume)
     *out_transaction_resume = ret_transaction_resume;
@@ -1374,8 +1374,16 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
 
   self->in_transaction = FALSE;
 
-  if (!ot_gfile_ensure_unlinked (self->transaction_lock_path, cancellable, error))
-    goto out;
+  if (unlinkat (self->repo_dir_fd, "transaction", 0) != 0)
+    {
+      if (errno == ENOENT)
+        ;
+      else
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+    }
 
   if (out_stats)
     *out_stats = self->txn_stats;


### PR DESCRIPTION
This originally was a way that we detected the case where a pull was
interrupted.  Later, we added `.commitpartial` files which also cover
this case.

See also https://github.com/GNOME/ostree/pull/85

We still want to honor their existence (and unlink them) in case an
old version of ostree was in use, but I believe it's safe to stop
creating them now.

The only case where this would break is if you have a version of
ostree that predates commitpartial in your rollback history, but such
old versions are no longer in use by operating systems I support at
least.