### PR TITLE
sysroot: Add a try_lock() API

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -369,6 +369,8 @@ ostree_sysroot_get_path
 ostree_sysroot_load
 ostree_sysroot_lock
 ostree_sysroot_try_lock
+ostree_sysroot_lock_async
+ostree_sysroot_lock_finish
 ostree_sysroot_unlock
 ostree_sysroot_get_fd
 ostree_sysroot_ensure_initialized

--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -368,6 +368,7 @@ ostree_sysroot_new_default
 ostree_sysroot_get_path
 ostree_sysroot_load
 ostree_sysroot_lock
+ostree_sysroot_try_lock
 ostree_sysroot_unlock
 ostree_sysroot_get_fd
 ostree_sysroot_ensure_initialized

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -1245,6 +1245,9 @@ lock_in_thread (GTask            *task,
   if (!ostree_sysroot_lock (self, &local_error))
     goto out;
 
+  if (g_cancellable_set_error_if_cancelled (cancellable, &local_error))
+    ostree_sysroot_unlock (self);
+  
  out:
   if (local_error)
     g_task_return_error (task, local_error);

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -63,6 +63,16 @@ char *ostree_sysroot_get_deployment_dirpath (OstreeSysroot    *self,
 GFile * ostree_sysroot_get_deployment_origin_path (GFile   *deployment_path);
 
 gboolean ostree_sysroot_lock (OstreeSysroot  *self, GError **error);
+gboolean ostree_sysroot_try_lock (OstreeSysroot         *self,
+                                  gboolean              *out_acquired,
+                                  GError               **error);
+void     ostree_sysroot_lock_async (OstreeSysroot         *self,
+                                    GCancellable          *cancellable,
+                                    GAsyncReadyCallback    callback,
+                                    gpointer               user_data);
+gboolean ostree_sysroot_lock_finish (OstreeSysroot         *self,
+                                     GAsyncResult          *result,
+                                     GError               **error);
 void ostree_sysroot_unlock (OstreeSysroot  *self);
 
 gboolean ostree_sysroot_cleanup (OstreeSysroot       *self,

--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -79,7 +79,7 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
 
   refspec = argv[1];
 
-  if (!ostree_sysroot_lock (sysroot, error))
+  if (!ot_admin_sysroot_lock (sysroot, error))
     goto out;
 
   if (!ostree_sysroot_load (sysroot, cancellable, error))

--- a/src/ostree/ot-admin-functions.h
+++ b/src/ostree/ot-admin-functions.h
@@ -41,5 +41,9 @@ ot_admin_get_indexed_deployment (OstreeSysroot  *sysroot,
                                  int             index,
                                  GError        **error);
 
+gboolean
+ot_admin_sysroot_lock (OstreeSysroot  *sysroot,
+                       GError        **error);
+
 
 G_END_DECLS


### PR DESCRIPTION
The blocking locking API wasn't sufficient for use in the rpm-ostree
daemon; it really wants to know if the lock is held, then continue to
do other things (like service DBus requests), and get notification
when the lock is available.

Implement a higher level "loop until lock is available" method in the
`ostree admin` commandline.

Now you can see how returning a dirfd which we then
`g_file_monitor_directory(/proc/self/fd/%d)` on is pretty ugly...  I
debated a few other options like an async notification, but there'd
need to be a sane way to distinguish between "I got the lock now"
versus "I waited for the lock".