### PR TITLE
Moar GPG utils

### DIFF
--- a/src/libotutil/ot-gpg-utils.h
+++ b/src/libotutil/ot-gpg-utils.h
@@ -34,4 +34,7 @@ gboolean ot_gpgme_ctx_tmp_home_dir (gpgme_ctx_t     gpgme_ctx,
                                     GCancellable   *cancellable,
                                     GError        **error);
 
+gpgme_data_t ot_gpgme_data_input (GInputStream *input_stream);
+gpgme_data_t ot_gpgme_data_output (GOutputStream *output_stream);
+
 G_END_DECLS


### PR DESCRIPTION
Snagged some handy GPG utilities from Seahorse.
https://git.gnome.org/browse/seahorse/tree/pgp/seahorse-gpgme-data.c

Found a use for `ot_gpgme_data_output()` in our `sign_data()` function, but mainly I need `ot_gpgme_data_input()` for the other GPG branch I'm working on.