### PR TITLE
admin: Use locking for most sysroot commands

### DIFF
--- a/src/ostree/ot-admin-builtin-deploy.c
+++ b/src/ostree/ot-admin-builtin-deploy.c
@@ -79,9 +79,6 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
 
   refspec = argv[1];
 
-  if (!ot_admin_sysroot_lock (sysroot, error))
-    goto out;
-
   if (!ostree_sysroot_load (sysroot, cancellable, error))
     goto out;
 
@@ -175,8 +172,6 @@ ot_admin_builtin_deploy (int argc, char **argv, GCancellable *cancellable, GErro
 
   ret = TRUE;
  out:
-  if (sysroot)
-    ostree_sysroot_unlock (sysroot);
   if (origin)
     g_key_file_unref (origin);
   if (context)

--- a/src/ostree/ot-admin-builtin-diff.c
+++ b/src/ostree/ot-admin-builtin-diff.c
@@ -55,7 +55,7 @@ ot_admin_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError 
   g_option_context_add_main_entries (context, options, NULL);
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                           &sysroot, cancellable, error))
     goto out;
   

--- a/src/ostree/ot-admin-builtin-init-fs.c
+++ b/src/ostree/ot-admin-builtin-init-fs.c
@@ -48,7 +48,7 @@ ot_admin_builtin_init_fs (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("PATH - Initialize a root filesystem");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-admin-builtin-instutil.c
+++ b/src/ostree/ot-admin-builtin-instutil.c
@@ -116,7 +116,7 @@ ot_admin_builtin_instutil (int argc, char **argv, GCancellable *cancellable, GEr
 
       /* This will not return for some options (e.g. --version). */
       if (ostree_admin_option_context_parse (context, NULL, &argc, &argv,
-                                             OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                             OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                              NULL, cancellable, error))
         {
           if (subcommand_name == NULL)

--- a/src/ostree/ot-admin-builtin-os-init.c
+++ b/src/ostree/ot-admin-builtin-os-init.c
@@ -46,7 +46,7 @@ ot_admin_builtin_os_init (int argc, char **argv, GCancellable *cancellable, GErr
   context = g_option_context_new ("OSNAME - Initialize empty state for given operating system");
 
   if (!ostree_admin_option_context_parse (context, options, &argc, &argv,
-                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER,
+                                          OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER | OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED,
                                           &sysroot, cancellable, error))
     goto out;
 

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "ostree.h"
+#include "ot-admin-functions.h"
 #include "ot-main.h"
 #include "otutil.h"
 
@@ -360,6 +361,12 @@ ostree_admin_option_context_parse (GOptionContext *context,
       g_print ("%s\n", deployment_path);
 
       exit (EXIT_SUCCESS);
+    }
+
+  if ((flags & OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED) == 0)
+    {
+      if (!ot_admin_sysroot_lock (sysroot, error))
+        goto out;
     }
 
   gs_transfer_out_value (out_sysroot, &sysroot);

--- a/src/ostree/ot-main.c
+++ b/src/ostree/ot-main.c
@@ -365,6 +365,7 @@ ostree_admin_option_context_parse (GOptionContext *context,
 
   if ((flags & OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED) == 0)
     {
+      /* Released when sysroot is finalized, or on process exit */
       if (!ot_admin_sysroot_lock (sysroot, error))
         goto out;
     }

--- a/src/ostree/ot-main.h
+++ b/src/ostree/ot-main.h
@@ -33,7 +33,8 @@ typedef enum {
 
 typedef enum {
   OSTREE_ADMIN_BUILTIN_FLAG_NONE = 0,
-  OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER = 1 << 0
+  OSTREE_ADMIN_BUILTIN_FLAG_SUPERUSER = 1 << 0,
+  OSTREE_ADMIN_BUILTIN_FLAG_UNLOCKED = 1 << 1
 } OstreeAdminBuiltinFlags;
 
 typedef struct {


### PR DESCRIPTION
The previous commit introduced locking for `ostree admin deploy`, but
we do expect people to possibly accidentally do e.g.
`ostree admin upgrade` concurrently.

Using consistent locking in the admin commands will help rpm-ostree.