### PR TITLE
repo: Bump mtime any time we write a ref

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -255,5 +255,9 @@ _ostree_repo_read_bare_fd (OstreeRepo           *self,
                            int                  *out_fd,
                            GCancellable        *cancellable,
                            GError             **error);
+
+gboolean
+_ostree_repo_update_mtime (OstreeRepo        *self,
+                           GError           **error);
                            
 G_END_DECLS

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -631,6 +631,9 @@ _ostree_repo_write_ref (OstreeRepo    *self,
         goto out;
     }
 
+  if (!_ostree_repo_update_mtime (self, error))
+    goto out;
+
   ret = TRUE;
  out:
   return ret;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -620,6 +620,18 @@ ostree_repo_is_writable (OstreeRepo *self,
   return self->writable;
 }
 
+gboolean
+_ostree_repo_update_mtime (OstreeRepo        *self,
+                           GError           **error)
+{
+  if (futimens (self->repo_dir_fd, NULL) != 0)
+    {
+      glnx_set_prefix_error_from_errno (error, "%s", "futimens");
+      return FALSE;
+    }
+  return TRUE;
+}
+
 /**
  * ostree_repo_get_config:
  * @self:

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -401,3 +401,16 @@ if test "$(id -u)" != "0"; then
     assert_file_has_content error-message "Permission denied"
     echo "ok unwritable repo was caught"
 fi
+
+cd ${test_tmpdir}
+rm -rf test2-checkout
+mkdir -p test2-checkout
+cd test2-checkout
+touch blah
+stat --printf="%Z\n" ${test_tmpdir}/repo > ${test_tmpdir}/timestamp-orig.txt
+$OSTREE commit -b test2 -s "Should bump the mtime"
+stat --printf="%Z\n" ${test_tmpdir}/repo > ${test_tmpdir}/timestamp-new.txt
+cd ..
+if ! cmp timestamp-{orig,new}.txt; then
+    assert_not_reached "failed to update mtime on repo"
+fi


### PR DESCRIPTION
External daemons like rpm-ostree want push notification any time a
change is made by an external entity.  inotify provides notification,
but a problem is there's no easy way to monitor all of the refs.

In the past, there has been discussion of opt-in recursive timestamps:
https://lkml.org/lkml/2013/4/5/307

But in today's world, let's just bump the mtime on the repo itself, as
a central inotify point.