### PR TITLE
repo: Add an API for intercepting file commits and returning cached v…

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -394,6 +394,15 @@ void ostree_repo_commit_modifier_set_xattr_callback (OstreeRepoCommitModifier   
                                                      GDestroyNotify                         destroy,
                                                      gpointer                               user_data);
 
+typedef char *(*OstreeRepoCommitModifierFileCacheCallback) (OstreeRepo     *repo,
+                                                            const char     *path,
+                                                            gpointer        user_data);
+
+void ostree_repo_commit_modifier_set_file_cache_callback (OstreeRepoCommitModifier              *modifier,
+                                                          OstreeRepoCommitModifierFileCacheCallback  callback,
+                                                          GDestroyNotify                         destroy,
+                                                          gpointer                               user_data);
+
 void ostree_repo_commit_modifier_set_sepolicy (OstreeRepoCommitModifier              *modifier,
                                                OstreeSePolicy                        *sepolicy);
 


### PR DESCRIPTION
…alues

Many people have observed that doing:

```
packagesystem --installroot=/var/tmp/blah
(cd blah && ostree commit ...)
```

is slow.  There are a number of ways to optimize this.  What
gnome-continuous does is to store separate subtrees for each
component, and union them.  Then on commit, it uses a reverse
(device,inode) -> checksum mapping to avoid re-checksumming subtrees
that haven't changed.

For rpm-ostree, doing this sort of thing with RPM is...hard.  It would
require changing how RPM writes to disk.  One thing we can do is
support external cache mechanisms.  And specifically one optimization
rpm-ostree can make is to create a mapping from
`(rpm version, filename) -> object checksum between the two trees.