### PR TITLE
ostree remote refs

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -80,6 +80,7 @@ ostree_SOURCES += \
 	src/ostree/ot-remote-builtin-gpg-import.c \
 	src/ostree/ot-remote-builtin-list.c \
 	src/ostree/ot-remote-builtin-show-url.c \
+        src/ostree/ot-remote-builtin-refs.c \
 	$(NULL)
 
 ostree_bin_shared_cflags = $(AM_CFLAGS) -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree -I$(srcdir)/src/ostree \

--- a/doc/ostree-remote.xml
+++ b/doc/ostree-remote.xml
@@ -63,6 +63,9 @@ Boston, MA 02111-1307, USA.
             <cmdsynopsis>
                 <command>ostree remote gpg-import</command> <arg choice="opt" rep="repeat">OPTIONS</arg> <arg choice="req">NAME</arg> <arg choice="opt" rep="repeat">KEY-ID</arg>
             </cmdsynopsis>
+            <cmdsynopsis>
+                <command>ostree remote refs</command> <arg choice="req">NAME</arg>
+            </cmdsynopsis>
     </refsynopsisdiv>
 
     <refsect1>

--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -234,6 +234,7 @@ ostree_repo_remote_list
 ostree_repo_remote_get_url
 ostree_repo_remote_get_gpg_verify
 ostree_repo_remote_gpg_import
+ostree_repo_remote_fetch_summary
 ostree_repo_get_parent
 ostree_repo_write_config
 OstreeRepoTransactionStats

--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -641,8 +641,10 @@ ostree_metalink_request_finish (OstreeMetalink         *self,
   if (g_task_propagate_boolean ((GTask*)result, error))
     {
       g_assert_cmpint (request->current_url_index, <, request->urls->len);
-      *out_target_uri = request->urls->pdata[request->current_url_index];
-      *out_data = g_strdup (request->result);
+      if (out_target_uri != NULL)
+        *out_target_uri = request->urls->pdata[request->current_url_index];
+      if (out_data != NULL)
+        *out_data = g_strdup (request->result);
       return TRUE;
     }
   else
@@ -700,7 +702,9 @@ _ostree_metalink_request_sync (OstreeMetalink        *self,
   data.out_data = out_data;
   data.loop = loop;
   data.error = error;
-  *fetching_sync_uri = _ostree_metalink_get_uri (self);
+
+  if (fetching_sync_uri != NULL)
+    *fetching_sync_uri = _ostree_metalink_get_uri (self);
 
   request->metalink = g_object_ref (self);
   request->urls = g_ptr_array_new_with_free_func ((GDestroyNotify) soup_uri_free);

--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -72,7 +72,7 @@ typedef struct
   char *verification_sha256;
   char *verification_sha512;
 
-  char *result;
+  GBytes *result;
 
   char *last_metalink_error;
   guint current_url_index;
@@ -427,48 +427,51 @@ on_fetched_url (GObject              *src,
                 gpointer              user_data)
 {
   GTask *task = user_data;
+  GCancellable *cancellable;
   OstreeMetalinkRequest *self = g_task_get_task_data (task);
   GError *local_error = NULL;
-  struct stat stbuf;
   int parent_dfd = _ostree_fetcher_get_dfd (self->metalink->fetcher);
   g_autoptr(GInputStream) instream = NULL;
-  g_autofree char *result = NULL;
-  GChecksum *checksum = NULL;
+  g_autoptr(GOutputStream) outstream = NULL;
+  g_autoptr(GBytes) bytes = NULL;
+  g_autofree char *path = NULL;
+  gssize n_bytes;
 
-  result = _ostree_fetcher_request_uri_with_partial_finish ((OstreeFetcher*)src, res, &local_error);
-  if (!result)
+  path = _ostree_fetcher_request_uri_with_partial_finish ((OstreeFetcher*)src, res, &local_error);
+  if (!path)
     goto out;
 
-  if (!ot_openat_read_stream (parent_dfd, result, FALSE,
-                              &instream, NULL, &local_error))
-    goto out;
-  
-  if (fstat (g_file_descriptor_based_get_fd ((GFileDescriptorBased*)instream), &stbuf) != 0)
-    {
-      gs_set_error_from_errno (&local_error, errno);
-      goto out;
-    }
+  cancellable = g_task_get_cancellable (task);
 
-  if (stbuf.st_size != self->size)
+  if (!ot_openat_read_stream (parent_dfd, path, FALSE, &instream,
+                              cancellable, &local_error))
+    goto out;
+
+  outstream = g_memory_output_stream_new_resizable ();
+
+  n_bytes = g_output_stream_splice (outstream, instream,
+                                    G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
+                                    G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+                                    cancellable, &local_error);
+
+  if (n_bytes < 0)
+    goto out;
+
+  bytes = g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (outstream));
+
+  if (n_bytes != self->size)
     {
       g_set_error (&local_error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Expected size is %" G_GUINT64_FORMAT " bytes but content is %" G_GUINT64_FORMAT " bytes",
-                   self->size, stbuf.st_size);
+                   "Expected size is %" G_GUINT64_FORMAT " bytes but content is %" G_GSSIZE_FORMAT " bytes",
+                   self->size, n_bytes);
       goto out;
     }
-  
+
   if (self->verification_sha512)
     {
-      const char *actual;
+      g_autofree char *actual = NULL;
 
-      checksum = g_checksum_new (G_CHECKSUM_SHA512);
-
-      if (!ot_gio_splice_update_checksum (NULL, instream, checksum,
-                                          g_task_get_cancellable (task),
-                                          &local_error))
-        goto out;
-      
-      actual = g_checksum_get_string (checksum);
+      actual = g_compute_checksum_for_bytes (G_CHECKSUM_SHA512, bytes);
 
       if (strcmp (self->verification_sha512, actual) != 0)
         {
@@ -480,16 +483,9 @@ on_fetched_url (GObject              *src,
     }
   else if (self->verification_sha256)
     {
-      const char *actual;
+      g_autofree char *actual = NULL;
 
-      checksum = g_checksum_new (G_CHECKSUM_SHA256);
-
-      if (!ot_gio_splice_update_checksum (NULL, instream, checksum,
-                                          g_task_get_cancellable (task),
-                                          &local_error))
-        goto out;
-
-      actual = g_checksum_get_string (checksum);
+      actual = g_compute_checksum_for_bytes (G_CHECKSUM_SHA256, bytes);
 
       if (strcmp (self->verification_sha256, actual) != 0)
         {
@@ -501,8 +497,6 @@ on_fetched_url (GObject              *src,
     }
 
  out:
-  if (checksum)
-    g_checksum_free (checksum);
   if (local_error)
     {
       g_free (self->last_metalink_error);
@@ -515,8 +509,7 @@ on_fetched_url (GObject              *src,
     }
   else
     {
-      self->result = result;
-      result = NULL; /* Transfer ownership */
+      self->result = g_bytes_ref (bytes);
       g_task_return_boolean (self->task, TRUE);
     }
 }
@@ -602,7 +595,7 @@ ostree_metalink_request_unref (gpointer data)
 {
   OstreeMetalinkRequest  *request = data;
   g_object_unref (request->metalink);
-  g_free (request->result);
+  g_clear_pointer (&request->result, g_bytes_unref);
   g_free (request->last_metalink_error);
   g_ptr_array_unref (request->urls);
   g_free (request);
@@ -619,7 +612,7 @@ static const GMarkupParser metalink_parser = {
 typedef struct
 {
   SoupURI               **out_target_uri;
-  char                  **out_data;
+  GBytes                **out_data;
   gboolean              success;
   GError                **error;
   GMainLoop             *loop;
@@ -629,7 +622,7 @@ static gboolean
 ostree_metalink_request_finish (OstreeMetalink         *self,
                                 GAsyncResult           *result,
                                 SoupURI               **out_target_uri,
-                                char                  **out_data,
+                                GBytes                **out_data,
                                 GError                **error)
 {
   OstreeMetalinkRequest *request;
@@ -644,7 +637,7 @@ ostree_metalink_request_finish (OstreeMetalink         *self,
       if (out_target_uri != NULL)
         *out_target_uri = request->urls->pdata[request->current_url_index];
       if (out_data != NULL)
-        *out_data = g_strdup (request->result);
+        *out_data = g_bytes_ref (request->result);
       return TRUE;
     }
   else
@@ -688,7 +681,7 @@ gboolean
 _ostree_metalink_request_sync (OstreeMetalink        *self,
                                GMainLoop             *loop,
                                SoupURI               **out_target_uri,
-                               char                  **out_data,
+                               GBytes                **out_data,
                                SoupURI               **fetching_sync_uri,
                                GCancellable          *cancellable,
                                GError                **error)

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -53,7 +53,7 @@ SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         GMainLoop             *loop,
                                         SoupURI               **out_target_uri,
-                                        char                  **out_data,
+                                        GBytes                **out_data,
                                         SoupURI               **fetching_sync_uri,
                                         GCancellable          *cancellable,
                                         GError                **error);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -196,6 +196,13 @@ _ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
                                         gboolean    *out_value,
                                         GError     **error);
 
+gboolean
+_ostree_repo_get_remote_option_inherit (OstreeRepo  *self,
+                                        const char  *remote_name,
+                                        const char  *option_name,
+                                        char       **out_value,
+                                        GError     **error);
+
 OstreeFetcher *
 _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
                                  const char  *remote_name,

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ostree-repo.h"
+#include "ostree-fetcher.h"
 
 G_BEGIN_DECLS
 
@@ -194,6 +195,11 @@ _ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
                                         gboolean     default_value,
                                         gboolean    *out_value,
                                         GError     **error);
+
+OstreeFetcher *
+_ostree_repo_remote_new_fetcher (OstreeRepo  *self,
+                                 const char  *remote_name,
+                                 GError     **error);
 
 OstreeGpgVerifyResult *
 _ostree_repo_gpg_verify_with_metadata (OstreeRepo          *self,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1673,19 +1673,15 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   if (_ostree_repo_remote_name_is_file (remote_name_or_baseurl))
     {
       baseurl = g_strdup (remote_name_or_baseurl);
-      /* For compatibility with pull-local, don't gpg verify local
-       * pulls.
-       */
-      pull_data->gpg_verify = FALSE;
     }
   else
     {
       pull_data->remote_name = g_strdup (remote_name_or_baseurl);
-
-      if (!ostree_repo_remote_get_gpg_verify (self, remote_name_or_baseurl,
-                                              &pull_data->gpg_verify, error))
-        goto out;
     }
+
+  if (!ostree_repo_remote_get_gpg_verify (self, remote_name_or_baseurl,
+                                          &pull_data->gpg_verify, error))
+    goto out;
 
   pull_data->phase = OSTREE_PULL_PHASE_FETCHING_REFS;
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1246,35 +1246,6 @@ enqueue_one_object_request (OtPullData        *pull_data,
 }
 
 static gboolean
-repo_get_remote_option_inherit (OstreeRepo  *self,
-                                const char  *remote_name,
-                                const char  *option_name,
-                                char       **out_value,
-                                GError     **error)
-{
-  OstreeRepo *parent = ostree_repo_get_parent (self);
-  g_autofree char *value = NULL;
-  gboolean ret = FALSE;
-
-  if (!_ostree_repo_get_remote_option (self, remote_name, option_name, NULL, &value, error))
-    goto out;
-
-  if (value == NULL && parent != NULL)
-    {
-        if (!repo_get_remote_option_inherit (parent, remote_name, option_name, &value, error))
-          goto out;
-    }
-
-  /* Success here just means no error occurred during lookup,
-   * not necessarily that we found a value for the option name. */
-  ot_transfer_out_value (out_value, &value);
-  ret = TRUE;
-
- out:
-  return ret;
-}
-
-static gboolean
 load_remote_repo_config (OtPullData    *pull_data,
                          GKeyFile     **out_keyfile,
                          GCancellable  *cancellable,
@@ -1735,7 +1706,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     {
       if (baseurl == NULL)
         {
-          if (!repo_get_remote_option_inherit (self, remote_name_or_baseurl, "url", &baseurl, error))
+          if (!_ostree_repo_get_remote_option_inherit (self, remote_name_or_baseurl, "url", &baseurl, error))
             goto out;
         }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1248,8 +1248,19 @@ ostree_repo_remote_get_gpg_verify (OstreeRepo  *self,
                                    gboolean    *out_gpg_verify,
                                    GError     **error)
 {
-  return _ostree_repo_get_remote_boolean_option (self, name, "gpg-verify",
-                                                 TRUE, out_gpg_verify, error);
+  g_return_val_if_fail (OSTREE_IS_REPO (self), FALSE);
+  g_return_val_if_fail (name != NULL, FALSE);
+
+  /* For compatibility with pull-local, don't GPG verify file:// URIs. */
+  if (_ostree_repo_remote_name_is_file (name))
+    {
+      if (out_gpg_verify != NULL)
+        *out_gpg_verify = FALSE;
+      return TRUE;
+    }
+
+ return _ostree_repo_get_remote_boolean_option (self, name, "gpg-verify",
+                                                TRUE, out_gpg_verify, error);
 }
 
 /**

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -120,6 +120,13 @@ gboolean      ostree_repo_remote_gpg_import (OstreeRepo         *self,
                                              GCancellable       *cancellable,
                                              GError            **error);
 
+gboolean      ostree_repo_remote_fetch_summary (OstreeRepo    *self,
+                                                const char    *name,
+                                                GBytes       **out_summary,
+                                                GBytes       **out_signatures,
+                                                GCancellable  *cancellable,
+                                                GError       **error);
+
 OstreeRepo * ostree_repo_get_parent (OstreeRepo  *self);
 
 gboolean      ostree_repo_write_config (OstreeRepo *self,

--- a/src/ostree/ot-builtin-remote.c
+++ b/src/ostree/ot-builtin-remote.c
@@ -37,6 +37,7 @@ static OstreeRemoteCommand remote_subcommands[] = {
   { "show-url", ot_remote_builtin_show_url },
   { "list", ot_remote_builtin_list },
   { "gpg-import", ot_remote_builtin_gpg_import },
+  { "refs", ot_remote_builtin_refs },
   { NULL, NULL }
 };
 

--- a/src/ostree/ot-remote-builtin-refs.c
+++ b/src/ostree/ot-remote-builtin-refs.c
@@ -1,0 +1,96 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "otutil.h"
+
+#include "ot-main.h"
+#include "ot-remote-builtins.h"
+
+static GOptionEntry option_entries[] = {
+};
+
+gboolean
+ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  const char *remote_name;
+  g_autoptr(GBytes) summary_bytes = NULL;
+  gboolean ret = FALSE;
+
+  context = g_option_context_new ("NAME - List remote refs");
+
+  if (!ostree_option_context_parse (context, option_entries, &argc, &argv,
+                                    OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    goto out;
+
+  if (argc < 2)
+    {
+      ot_util_usage_error (context, "NAME must be specified", error);
+      goto out;
+    }
+
+  remote_name = argv[1];
+
+  if (!ostree_repo_remote_fetch_summary (repo, remote_name,
+                                         &summary_bytes, NULL,
+                                         cancellable, error))
+    goto out;
+
+  if (summary_bytes == NULL)
+    {
+      g_print ("Remote refs not available; server has no summary file\n");
+    }
+  else
+    {
+      g_autoptr(GVariant) summary = NULL;
+      g_autoptr(GVariant) ref_map = NULL;
+      GVariantIter iter;
+      GVariant *child;
+
+      summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT,
+                                          summary_bytes, FALSE);
+
+      ref_map = g_variant_get_child_value (summary, 0);
+
+      /* Ref map should already be sorted by ref name. */
+      g_variant_iter_init (&iter, ref_map);
+      while ((child = g_variant_iter_next_value (&iter)) != NULL)
+        {
+          const char *ref_name = NULL;
+
+          g_variant_get_child (child, 0, "&s", &ref_name);
+
+          if (ref_name != NULL)
+            g_print ("%s\n", ref_name);
+
+          g_variant_unref (child);
+        }
+    }
+
+  ret = TRUE;
+
+out:
+  g_option_context_free (context);
+
+  return ret;
+}

--- a/src/ostree/ot-remote-builtins.h
+++ b/src/ostree/ot-remote-builtins.h
@@ -29,5 +29,6 @@ gboolean ot_remote_builtin_delete (int argc, char **argv, GCancellable *cancella
 gboolean ot_remote_builtin_gpg_import (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error);
 gboolean ot_remote_builtin_show_url (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean ot_remote_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error);
 
 G_END_DECLS

--- a/tests/test-pull-metalink.sh
+++ b/tests/test-pull-metalink.sh
@@ -70,6 +70,11 @@ ${CMD_PREFIX} ostree --repo=repo rev-parse origin:main
 ${CMD_PREFIX} ostree --repo=repo fsck
 echo "ok pull via metalink"
 
+# Test fetching the summary through ostree_repo_remote_fetch_summary()
+${CMD_PREFIX} ostree --repo=repo remote refs origin > origin_refs
+assert_file_has_content origin_refs "main"
+echo "ok remote refs via metalink"
+
 cp metalink-data/metalink.xml{,.orig}
 cp ostree-srv/gnomerepo/summary{,.orig}
 


### PR DESCRIPTION
Implements the `ostree remote refs` command I proposed in https://bugzilla.gnome.org/749456 but uses the remote repo's `summary` file.  Any repo being served over HTTP really *ought* to have one.

The first 4 commits are just some refactoring that I think are worth adding regardless of the command.