### PR TITLE
pull: Error if gpg=true and summary is 404, add more tests

### DIFF
--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -28,12 +28,12 @@ setup_fake_remote_repo1 "archive-z2" "${COMMIT_SIGN}"
 mkdir ${test_tmpdir}/ostree-srv/other-files
 cd ${test_tmpdir}/ostree-srv/other-files
 echo 'hello world another object' > hello-world
-ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit ${COMMIT_SIGN} -b other -s "A commit" -m "Another Commit body"
+ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit -b other -s "A commit" -m "Another Commit body"
 
 mkdir ${test_tmpdir}/ostree-srv/yet-other-files
 cd ${test_tmpdir}/ostree-srv/yet-other-files
 echo 'hello world yet another object' > yet-another-hello-world
-ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit ${COMMIT_SIGN} -b yet-another -s "A commit" -m "Another Commit body"
+ostree  --repo=${test_tmpdir}/ostree-srv/gnomerepo commit -b yet-another -s "A commit" -m "Another Commit body"
 
 ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u
 
@@ -60,22 +60,46 @@ cd $prev_dir
 
 ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
+repo_reinit () {
+  cd ${test_tmpdir}
+  rm -rf repo
+  mkdir repo
+  ${OSTREE} --repo=repo init --mode=archive-z2
+  ${OSTREE} --repo=repo remote add --set=gpg-verify-summary=true origin $(cat httpd-address)/ostree/gnomerepo
+}
+
 cd ${test_tmpdir}
-rm -rf repo
-mkdir repo
-${OSTREE} --repo=repo init --mode=archive-z2
-${OSTREE} --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
+repo_reinit
 ${OSTREE} --repo=repo pull origin main
 echo "ok pull with signed summary"
+
+cd ${test_tmpdir}
+repo_reinit
+mv ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{,.good}
+echo invalid > ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig
+if ${OSTREE} --repo=repo pull origin main 2>err.txt; then
+    assert_not_reached "Successful pull with invalid GPG sig"
+fi
+assert_file_has_content err.txt "no signatures found"
+mv ${test_tmpdir}/ostree-srv/gnomerepo/summary.sig{.good,}
+echo "ok pull with invalid summary gpg signature fails"
+
+cd ${test_tmpdir}
+repo_reinit
+cp ${test_tmpdir}/ostree-srv/gnomerepo/summary{,.good}
+# Some leading garbage
+(echo invalid && cat ${test_tmpdir}/ostree-srv/gnomerepo/summary) > summary.bad.tmp && mv summary.bad.tmp ${test_tmpdir}/ostree-srv/gnomerepo/summary
+if ${OSTREE} --repo=repo pull origin main; then
+    assert_not_reached "Successful pull with invalid summary"
+fi
+mv ${test_tmpdir}/ostree-srv/gnomerepo/summary{.good,}
+echo "ok pull with invalid summary (leading garbage) fails"
 
 # Generate a delta
 ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo static-delta generate --empty main
 ${OSTREE} --repo=${test_tmpdir}/ostree-srv/gnomerepo summary -u ${COMMIT_SIGN}
 
 cd ${test_tmpdir}
-rm -rf repo
-mkdir repo
-${OSTREE} --repo=repo init --mode=archive-z2
-${OSTREE} --repo=repo remote add origin $(cat httpd-address)/ostree/gnomerepo
+repo_reinit
 ${OSTREE} --repo=repo pull origin main
 echo "ok pull delta with signed summary"


### PR DESCRIPTION
I did a quick audit pass through the pull code.  What I focused on the
most is the case where `gpg-verify-summary=true`, and in particular
where `gpg-verify=false` too.  This should be a valid and secure
configuration.

The primary change here is to error out very quickly if either
`summary` or `summary.sig` are 404.  Previously, we'd only error out
if we were processing deltas.

Expand the existing test case to cover this, plus invalid summary and
invalid sig.  (The test case was failing with current git master too).