### PR TITLE
build: autogen.sh no longer silently fails if gtk-doc is missing.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,7 @@ set -e
 
 mkdir -p m4
 
-GTKDOCIZE=$(which gtkdocize 2>/dev/null)
+GTKDOCIZE=$(which gtkdocize 2>/dev/null || true)
 if test -z $GTKDOCIZE; then
         echo "You don't have gtk-doc installed, and thus won't be able to generate the documentation."
         rm -f gtk-doc.make

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,14 @@ OSTREE_FEATURES="$OSTREE_FEATURES +gpgme"
 
 LIBARCHIVE_DEPENDENCY="libarchive >= 2.8.0"
 
+# check for gtk-doc
+m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
+],[
+enable_gtk_doc=no
+AM_CONDITIONAL([ENABLE_GTK_DOC], false)
+])
+
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 AC_ARG_WITH(libarchive,


### PR DESCRIPTION
If gtk-doc wasn't installed, the autogen.sh script would silently stop when it executed `which gtkdocize` because of `set -e`. This fixes that and makes the gtk-doc package optional. I'm brand new to autotools so I apologize in advance if I've done this all wrong.