### PR TITLE
ostree: add colored output to tty

### DIFF
--- a/src/libostree/ostree-diff.c
+++ b/src/libostree/ostree-diff.c
@@ -444,14 +444,20 @@ ostree_diff_print (GFile          *a,
       OstreeDiffItem *diff = modified->pdata[i];
       print_diff_item ('M', a, diff->src);
     }
+
+  glnx_console_set_color (GLNX_COLOR_RED, GLNX_COLOR_STYLE_REGULAR, 0, 0);
   for (i = 0; i < removed->len; i++)
     {
       GFile *removed_file = removed->pdata[i];
       print_diff_item ('D', a, removed_file);
     }
+  glnx_console_reset_color (FALSE);
+
+  glnx_console_set_color (GLNX_COLOR_GREEN, GLNX_COLOR_STYLE_REGULAR, 0, 0);
   for (i = 0; i < added->len; i++)
     {
       GFile *added_f = added->pdata[i];
       print_diff_item ('A', b, added_f);
     }
+  glnx_console_reset_color (FALSE);
 }

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -78,17 +78,12 @@ main (int    argc,
   if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED))
     ostree_usage (commands, TRUE);
 
+  glnx_console_install_signal_handlers ();
   if (error != NULL)
     {
-      int is_tty = isatty (1);
-      const char *prefix = "";
-      const char *suffix = "";
-      if (is_tty)
-        {
-          prefix = "\x1b[31m\x1b[1m"; /* red, bold */
-          suffix = "\x1b[22m\x1b[0m"; /* bold off, color reset */
-        }
-      g_printerr ("%serror: %s%s\n", prefix, suffix, error->message);
+      glnx_console_set_color (GLNX_COLOR_RED, GLNX_COLOR_STYLE_BOLD, 0, 0);
+      g_printerr ("error: %s\n", error->message);
+      glnx_console_reset_color (FALSE);
       g_error_free (error);
     }
 

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -126,7 +126,9 @@ ot_dump_object (OstreeObjectType   objtype,
                 GVariant          *variant,
                 OstreeDumpFlags    flags)
 {
+  glnx_console_set_color (GLNX_COLOR_YELLOW, GLNX_COLOR_STYLE_REGULAR, 0, 0);
   g_print ("%s %s\n", ostree_object_type_to_string (objtype), checksum);
+  glnx_console_reset_color (FALSE);
 
   if (flags & OSTREE_DUMP_RAW)
     {


### PR DESCRIPTION
DEPENDS FROM: https://github.com/GNOME/libglnx/pull/10

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>