### PR TITLE
pull: Only fetch all refs if we're mirroring

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1932,7 +1932,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
             if (!ostree_validate_rev (refname, error))
               goto out;
 
-            g_hash_table_insert (requested_refs_to_fetch, g_strdup (refname), NULL);
+            if (pull_data->is_mirror && !refs_to_fetch)
+              g_hash_table_insert (requested_refs_to_fetch, g_strdup (refname), NULL);
           }
 
         additional_metadata = g_variant_get_child_value (pull_data->summary, 1);


### PR DESCRIPTION
I noticed xdg-app was looping trying to fetch 1427 refs.  We
don't want to do that unless asked to.

(And also, we need to make static delta requests async)