### PR TITLE
tests: Add a test for pull+deploy of specific "bare" commit

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -49,6 +49,7 @@ testfiles = test-basic \
 	test-admin-deploy-uboot \
 	test-admin-instutil-set-kargs \
 	test-admin-upgrade-not-backwards \
+	test-admin-pull-deploy-commit \
 	test-admin-locking \
 	test-repo-checkout-subpath	\
 	test-reset-nonlinear \

--- a/tests/test-admin-pull-deploy-commit.sh
+++ b/tests/test-admin-pull-deploy-commit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+echo "1..1"
+
+setup_os_repository "archive-z2" "syslinux"
+
+cd ${test_tmpdir}
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo remote add --set=gpg-verify=false testos $(cat httpd-address)/ostree/testos-repo
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos testos/buildmaster/x86_64-runtime
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+parent_rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse ${rev}^)
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull testos ${parent_rev}
+${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos ${parent_rev}
+
+echo 'ok deploy pulled commit'


### PR DESCRIPTION
This is the "pull an older version" that's now supported since
36d65b3cfcc9557552314d112493516437d6fcd4

However...this test does *not* fail when I revert the commits that were supposed to make it work.  I'm still debugging that.