### PR TITLE
sysroot: Cleanup refs and prune even on last undeployment

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -50,6 +50,7 @@ testfiles = test-basic \
 	test-admin-instutil-set-kargs \
 	test-admin-upgrade-not-backwards \
 	test-admin-locking \
+	test-admin-deploy-clean \
 	test-repo-checkout-subpath	\
 	test-reset-nonlinear \
 	test-oldstyle-partial \

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -570,23 +570,20 @@ _ostree_sysroot_piecemeal_cleanup (OstreeSysroot              *self,
         goto out;
     }
 
-  if (self->deployments->len > 0)
+  if (!ostree_sysroot_get_repo (self, &repo, cancellable, error))
+    goto out;
+  
+  if (!generate_deployment_refs (self, repo,
+                                 self->bootversion,
+                                 self->subbootversion,
+                                 self->deployments,
+                                 cancellable, error))
+    goto out;
+  
+  if (flags & OSTREE_SYSROOT_CLEANUP_PRUNE_REPO)
     {
-      if (!ostree_sysroot_get_repo (self, &repo, cancellable, error))
-        goto out;
-
-      if (!generate_deployment_refs (self, repo,
-                                     self->bootversion,
-                                     self->subbootversion,
-                                     self->deployments,
-                                     cancellable, error))
-        goto out;
-
-      if (flags & OSTREE_SYSROOT_CLEANUP_PRUNE_REPO)
-        {
-          if (!prune_repo (repo, cancellable, error))
+      if (!prune_repo (repo, cancellable, error))
             goto out;
-        }
     }
 
   ret = TRUE;

--- a/tests/test-admin-deploy-clean.sh
+++ b/tests/test-admin-deploy-clean.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+# Exports OSTREE_SYSROOT so --sysroot not needed.
+setup_os_repository "archive-z2" "syslinux"
+
+echo "1..1"
+
+ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
+rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
+export rev
+ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+ostree admin undeploy 0
+ostree --repo=sysroot/ostree/repo refs > refs.txt
+assert_not_file_has_content refs.txt '^ostree/'
+
+echo "ok deploy + undeploy repo prune"


### PR DESCRIPTION
I was working on a different test, and ended up being very confused at
the behavior where removing the last deployment didn't remove the last
`ostree/X/X/X` ref pointing to its commit.

There's no reason to special case the last undeployment AFAIK, and the
existing code handles this.