### PR TITLE
cmdline: Fatally error if the timestamp in a commit is invalid

### DIFF
--- a/src/ostree/ot-builtin-commit.c
+++ b/src/ostree/ot-builtin-commit.c
@@ -497,6 +497,11 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
           GDateTime *now = g_date_time_new_now_utc ();
           timestamp = g_date_time_to_unix (now);
           g_date_time_unref (now);
+
+          if (!ostree_repo_write_commit (repo, parent, opt_subject, opt_body, metadata,
+                                         OSTREE_REPO_FILE (root),
+                                         &commit_checksum, cancellable, error))
+            goto out;
         }
       else
         {
@@ -508,13 +513,13 @@ ostree_builtin_commit (int argc, char **argv, GCancellable *cancellable, GError 
               goto out;
             }
           timestamp = ts.tv_sec;
-        }
 
-      if (!ostree_repo_write_commit_with_time (repo, parent, opt_subject, opt_body, metadata,
-                                               OSTREE_REPO_FILE (root),
-                                               timestamp,
-                                               &commit_checksum, cancellable, error))
-        goto out;
+          if (!ostree_repo_write_commit_with_time (repo, parent, opt_subject, opt_body, metadata,
+                                                   OSTREE_REPO_FILE (root),
+                                                   timestamp,
+                                                   &commit_checksum, cancellable, error))
+            goto out;
+        }
 
       if (detached_metadata)
         {


### PR DESCRIPTION
Previously we were just ignoring this, which hid a bug in
an earlier commit that generated them.

Also change the `commit` program to use both APIs - this
involves extra code, but not too much.

This way, reverting the fix with this on top caused the test suite to
fail.  Adding an active test for this would need a custom test program
using the C API, or adding a cmdline flag to the client, neither of
which quite seemed worth it.