### PR TITLE
fetcher: Lazily create tmp directory

### DIFF
--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -55,9 +55,7 @@ typedef enum {
 GType   _ostree_fetcher_get_type (void) G_GNUC_CONST;
 
 OstreeFetcher *_ostree_fetcher_new (int                      tmpdir_dfd,
-                                    OstreeFetcherConfigFlags flags,
-                                    GCancellable            *cancellable,
-                                    GError                 **error);
+                                    OstreeFetcherConfigFlags flags);
 
 int  _ostree_fetcher_get_dfd (OstreeFetcher *fetcher);
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -419,9 +419,7 @@ _ostree_repo_remote_new_fetcher (OstreeRepo  *self,
   if (tls_permissive)
     fetcher_flags |= OSTREE_FETCHER_FLAGS_TLS_PERMISSIVE;
 
-  fetcher = _ostree_fetcher_new (self->tmp_dir_fd, fetcher_flags, NULL, error);
-  if (fetcher == NULL)
-    goto out;
+  fetcher = _ostree_fetcher_new (self->tmp_dir_fd, fetcher_flags);
 
   {
     g_autofree char *tls_client_cert_path = NULL;


### PR DESCRIPTION
This is an alternative to PR https://github.com/GNOME/ostree/pull/162 based on subsequent discussion.

The tmpdir is now lazily created from the new `SoupSession` thread instead of at instance initialization, so `OstreeFetcher` instances that only need to use `_ostree_fetcher_request_uri_to_membuf()` as a normal user won't encounter permission issues creating a tmpdir it doesn't need.