### PR TITLE
grub2_generate: load sysroot before using it

### DIFF
--- a/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
+++ b/src/ostree/ot-admin-instutil-builtin-grub2-generate.c
@@ -52,6 +52,9 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
                                           &sysroot, cancellable, error))
     goto out;
 
+  if (!ostree_sysroot_load (sysroot, cancellable, error))
+    goto out;
+
   if (argc >= 2)
     {
       bootversion = (guint) g_ascii_strtoull (argv[1], NULL, 10);
@@ -71,9 +74,6 @@ ot_admin_instutil_builtin_grub2_generate (int argc, char **argv, GCancellable *c
         bootversion = ostree_sysroot_get_bootversion (sysroot);
       g_assert (bootversion == 0 || bootversion == 1);
     }
-
-  if (!ostree_sysroot_load (sysroot, cancellable, error))
-    goto out;
 
   if (!ostree_cmd__private__()->ostree_generate_grub2_config (sysroot, bootversion, 1, cancellable, error))
     goto out;


### PR DESCRIPTION
The logic for checking which bootversion to use tries to access
sysroot->bootversion if the user didn't specify an explicit bootversion
on the command-line nor through the env var. However, at that point, the
sysroot object is not yet initialized, so it will always return 0, even
when it's 1.

This would cause e.g. `grub2-mkconfig` to have no output for the BLS
entries whenever the entries were under `/boot/loader.1`.

Related: RHBZ1293986