### PR TITLE
sysroot: Don't individually fsync dirs in checkout, rely on syncfs

### DIFF
--- a/doc/ostree-sections.txt
+++ b/doc/ostree-sections.txt
@@ -220,6 +220,7 @@ ostree_repo_new_for_sysroot_path
 ostree_repo_new_default
 ostree_repo_open
 ostree_repo_set_disable_fsync
+ostree_repo_get_disable_fsync
 ostree_repo_is_system
 ostree_repo_is_writable
 ostree_repo_create

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2384,6 +2384,19 @@ ostree_repo_set_disable_fsync (OstreeRepo    *self,
   self->disable_fsync = disable_fsync;
 }
 
+/**
+ * ostree_repo_get_disable_fsync:
+ * @self: An #OstreeRepo
+ *
+ * For more information see ostree_repo_set_disable_fsync().
+ *
+ * Returns: Whether or not fsync() is enabled for this repo.
+ */
+gboolean
+ostree_repo_get_disable_fsync (OstreeRepo    *self)
+{
+  return self->disable_fsync;
+}
 
 /* Replace the contents of a file, honoring the repository's fsync
  * policy.

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -56,6 +56,8 @@ gboolean      ostree_repo_open   (OstreeRepo     *self,
 void          ostree_repo_set_disable_fsync (OstreeRepo    *self,
                                              gboolean       disable_fsync);
 
+gboolean      ostree_repo_get_disable_fsync (OstreeRepo    *self);
+
 gboolean      ostree_repo_is_system (OstreeRepo   *repo);
 
 gboolean      ostree_repo_is_writable (OstreeRepo  *self,


### PR DESCRIPTION
Originally, a lot of the `fsync()` calls here were added for the
wrong reason - I was chasing a bug that ended up being the extlinux
bootloader not parsing 64 bit ext4 filesystems.  But since it looked
like corruption, I tried adding a lot more `fsync()` calls.

All we should have to do is use `syncfs()`.  If that doesn't work,
it's a kernel bug.

I'm making this change because skipping the individual fsyncs can be a
major performance win - it's easier for the FS to optimize, we do more
in parallel, etc.

https://bugzilla.gnome.org/show_bug.cgi?id=757117