### PR TITLE
Add a checkout option to skip fsync

### DIFF
--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -532,7 +532,8 @@ typedef struct {
   OstreeRepoCheckoutOverwriteMode overwrite_mode;
   
   guint enable_uncompressed_cache : 1;
-  guint unused : 31;
+  guint disable_fsync : 1;
+  guint reserved : 30;
 
   const char *subpath;
 


### PR DESCRIPTION
This is a better followup to dc9239dd7b09ef5e104309b4dbf0e136889da274
since I wanted to do fsync-less checkouts in rpm-ostree too, and
replicating the "turn off fsync temporarily" was in retrospect just a
hack.

We can simply add a boolean to the checkout options.