### PR TITLE
repo: Port -refs.c to openat()

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -50,8 +50,6 @@ struct OstreeRepo {
   int    repo_dir_fd;
   GFile *tmp_dir;
   int    tmp_dir_fd;
-  GFile *local_heads_dir;
-  GFile *remote_heads_dir;
   GFile *objects_dir;
   GFile *state_dir;
   int objects_dir_fd;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -518,8 +518,6 @@ ostree_repo_finalize (GObject *object)
   g_clear_object (&self->tmp_dir);
   if (self->tmp_dir_fd)
     (void) close (self->tmp_dir_fd);
-  g_clear_object (&self->local_heads_dir);
-  g_clear_object (&self->remote_heads_dir);
   g_clear_object (&self->objects_dir);
   if (self->objects_dir_fd != -1)
     (void) close (self->objects_dir_fd);
@@ -605,8 +603,6 @@ ostree_repo_constructed (GObject *object)
   g_assert (self->repodir != NULL);
 
   self->tmp_dir = g_file_resolve_relative_path (self->repodir, "tmp");
-  self->local_heads_dir = g_file_resolve_relative_path (self->repodir, "refs/heads");
-  self->remote_heads_dir = g_file_resolve_relative_path (self->repodir, "refs/remotes");
 
   self->objects_dir = g_file_get_child (self->repodir, "objects");
   self->deltas_dir = g_file_get_child (self->repodir, "deltas");

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -155,6 +155,8 @@ assert_not_streq ${rev} ${newrev}
 assert_file_has_content sysroot/ostree/deploy/testos/deploy/${newrev}.0/etc/os-release 'NAME=TestOS'
 ${CMD_PREFIX} ostree admin status
 validate_bootloader
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo refs testos:testos > reftest.txt
+assert_file_has_content reftest.txt testos:buildmaster/x86_64-runtime
 
 echo "ok upgrade"
 


### PR DESCRIPTION
I'd like to incrementally convert all of `ostree-repo*.c` to
fd-relative usage, so that we can sanely introduce
`ostree_repo_new_at()` which doesn't involve GFile.

This one is medium risk, but passes the test suite.