### PR TITLE
tests: Use "bash strict mode"

### DIFF
--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -16,7 +16,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..10"
 

--- a/tests/archive-test.sh
+++ b/tests/archive-test.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 $OSTREE checkout test2 checkout-test2
 echo "ok checkout"

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..48"
 

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -33,11 +33,11 @@ cp -a ${SRCDIR}/gpghome ${test_tmpdir}
 export TEST_GPG_KEYHOME=${test_tmpdir}/gpghome
 export OSTREE_GPG_HOME=${test_tmpdir}/gpghome/trusted
 
-if test -n "${OT_TESTS_DEBUG}"; then
+if test -n "${OT_TESTS_DEBUG:-}"; then
     set -x
 fi
 
-if test -n "$OT_TESTS_VALGRIND"; then
+if test -n "${OT_TESTS_VALGRIND:-}"; then
     CMD_PREFIX="env G_SLICE=always-malloc valgrind -q --leak-check=full --num-callers=30 --suppressions=${SRCDIR}/ostree-valgrind.supp"
 else
     CMD_PREFIX="env LD_PRELOAD=${SRCDIR}/libreaddir-rand.so"
@@ -139,8 +139,8 @@ setup_test_repository () {
 
 setup_fake_remote_repo1() {
     mode=$1
-    commit_opts=$2
-    args=$3
+    commit_opts=${2:-}
+    args=${3:-}
     shift
     oldpwd=`pwd`
     mkdir ostree-srv
@@ -272,7 +272,7 @@ EOF
     mkdir ${test_tmpdir}/httpd
     cd httpd
     ln -s ${test_tmpdir} ostree
-    ${CMD_PREFIX} ostree trivial-httpd --autoexit --daemonize -p ${test_tmpdir}/httpd-port $args
+    ${CMD_PREFIX} ostree trivial-httpd --autoexit --daemonize -p ${test_tmpdir}/httpd-port
     port=$(cat ${test_tmpdir}/httpd-port)
     echo "http://127.0.0.1:${port}" > ${test_tmpdir}/httpd-address
     cd ${oldpwd} 
@@ -280,15 +280,9 @@ EOF
 
 os_repository_new_commit ()
 {
-    boot_checksum_iteration=$1
-    content_iteration=$2
+    boot_checksum_iteration=${1:-0}
+    content_iteration=${2:-0}
     echo "BOOT ITERATION: $boot_checksum_iteration"
-    if test -z "$boot_checksum_iteration"; then
-	boot_checksum_iteration=0
-    fi
-    if test -z "$content_iteration"; then
-	content_iteration=0
-    fi
     cd ${test_tmpdir}/osdata
     rm boot/*
     echo "new: a kernel ${boot_checksum_iteration}" > boot/vmlinuz-3.6.0

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 function repo_init() {
     cd ${test_tmpdir}

--- a/tests/test-admin-deploy-2.sh
+++ b/tests/test-admin-deploy-2.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
@@ -49,7 +49,6 @@ os_repository_new_commit "1"
 bootcsum3=${bootcsum}
 ${CMD_PREFIX} ostree admin upgrade --os=testos
 
-rev=${newrev}
 newrev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 assert_not_streq ${rev} ${newrev}
 assert_not_streq ${bootcsum1} ${bootcsum2}

--- a/tests/test-admin-deploy-clean.sh
+++ b/tests/test-admin-deploy-clean.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-etcmerge-cornercases.sh
+++ b/tests/test-admin-deploy-etcmerge-cornercases.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-grub2.sh
+++ b/tests/test-admin-deploy-grub2.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-switch.sh
+++ b/tests/test-admin-deploy-switch.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -18,7 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -18,7 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-locking.sh
+++ b/tests/test-admin-locking.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-pull-deploy-commit.sh
+++ b/tests/test-admin-pull-deploy-commit.sh
@@ -19,7 +19,7 @@
 
 # See https://github.com/GNOME/ostree/pull/145
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-upgrade-not-backwards.sh
+++ b/tests/test-admin-upgrade-not-backwards.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-upgrade-unconfigured.sh
+++ b/tests/test-admin-upgrade-unconfigured.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-archivez.sh
+++ b/tests/test-archivez.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-auto-summary.sh
+++ b/tests/test-auto-summary.sh
@@ -18,7 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-basic-user.sh
+++ b/tests/test-basic-user.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-commit-sign.sh
+++ b/tests/test-commit-sign.sh
@@ -17,9 +17,9 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then
+if ! ostree --version | grep -q -e '\+gpgme'; then
     exit 77
 fi
 

--- a/tests/test-corruption.sh
+++ b/tests/test-corruption.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..2"
 

--- a/tests/test-delta.sh
+++ b/tests/test-delta.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-gpg-signed-commit.sh
+++ b/tests/test-gpg-signed-commit.sh
@@ -18,9 +18,9 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then
+if ! ostree --version | grep -q -e '\+gpgme'; then
     exit 77
 fi
 

--- a/tests/test-help.sh
+++ b/tests/test-help.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
@@ -45,7 +45,7 @@ test_recursive() {
         if [ $? = 0 ] ; then
 	    echo 1>&2 "missing subcommand but 0 exit status"; exit 1
         fi
-        set -e
+        set -euo pipefail
         # error message and usage goes to standard error
         assert_file_has_content err "[Uu]sage"
         assert_file_has_content err "$cmd"

--- a/tests/test-libarchive.sh
+++ b/tests/test-libarchive.sh
@@ -17,9 +17,9 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+libarchive'; then
+if ! ostree --version | grep -q -e '\+libarchive'; then
     exit 77
 fi
 

--- a/tests/test-local-pull-depth.sh
+++ b/tests/test-local-pull-depth.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-local-pull.sh
+++ b/tests/test-local-pull.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-oldstyle-partial.sh
+++ b/tests/test-oldstyle-partial.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-prune.sh
+++ b/tests/test-prune.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-archive-z.sh
+++ b/tests/test-pull-archive-z.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-commit-only.sh
+++ b/tests/test-pull-commit-only.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-corruption.sh
+++ b/tests/test-pull-corruption.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
@@ -55,4 +55,4 @@ gjs --help >/dev/null 2>&1 || exit 77
 gjs $(dirname $0)/corrupt-repo-ref.js ${repopath} main || true
 assert_file_has_content corrupted-status.txt 'Changed byte'
 do_corrupt_pull_test
-echo "ok corruption $iteration"
+echo "ok corruption"

--- a/tests/test-pull-depth.sh
+++ b/tests/test-pull-depth.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-large-metadata.sh
+++ b/tests/test-pull-large-metadata.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-metalink.sh
+++ b/tests/test-pull-metalink.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-resume.sh
+++ b/tests/test-pull-resume.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-subpath.sh
+++ b/tests/test-pull-subpath.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-pull-summary-sigs.sh
+++ b/tests/test-pull-summary-sigs.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-remote-add.sh
+++ b/tests/test-remote-add.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-remote-gpg-import.sh
+++ b/tests/test-remote-gpg-import.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-repo-checkout-subpath.sh
+++ b/tests/test-repo-checkout-subpath.sh
@@ -18,7 +18,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-reset-nonlinear.sh
+++ b/tests/test-reset-nonlinear.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-setuid.sh
+++ b/tests/test-setuid.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 echo "1..1"
 

--- a/tests/test-xattrs.sh
+++ b/tests/test-xattrs.sh
@@ -17,7 +17,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
 touch test-xattrs
 if ! setfattr -n user.testvalue -v somevalue test-xattrs; then


### PR DESCRIPTION
I noticed in the static deltas tests, there were some tests that
should have been under `-o pipefail` to ensure we properly propagate
errors.

There were a few places where we were referencing undefined variables.

Overall, this is clearly a good idea IMO.