### PR TITLE
lib: Add a #define OSTREE_SHA256_DIGEST_LEN 32

### DIFF
--- a/src/libostree/ostree-core.c
+++ b/src/libostree/ostree-core.c
@@ -1069,7 +1069,7 @@ int
 ostree_cmp_checksum_bytes (const guchar *a,
                            const guchar *b)
 {
-  return memcmp (a, b, 32);
+  return memcmp (a, b, OSTREE_SHA256_DIGEST_LEN);
 }
 
 /**
@@ -1151,7 +1151,7 @@ ostree_checksum_inplace_to_bytes (const char *checksum,
   guint i;
   guint j;
 
-  for (i = 0, j = 0; i < 32; i += 1, j += 2)
+  for (i = 0, j = 0; i < OSTREE_SHA256_DIGEST_LEN; i += 1, j += 2)
     {
       gint big, little;
 
@@ -1177,7 +1177,7 @@ ostree_checksum_inplace_to_bytes (const char *checksum,
 guchar *
 ostree_checksum_to_bytes (const char *checksum)
 {
-  guchar *ret = g_malloc (32);
+  guchar *ret = g_malloc (OSTREE_SHA256_DIGEST_LEN);
   ostree_checksum_inplace_to_bytes (checksum, ret);
   return ret;
 }
@@ -1191,9 +1191,9 @@ ostree_checksum_to_bytes (const char *checksum)
 GVariant *
 ostree_checksum_to_bytes_v (const char *checksum)
 {
-  guchar result[32];
+  guchar result[OSTREE_SHA256_DIGEST_LEN];
   ostree_checksum_inplace_to_bytes (checksum, result);
-  return ot_gvariant_new_bytearray ((guchar*)result, 32);
+  return ot_gvariant_new_bytearray ((guchar*)result, OSTREE_SHA256_DIGEST_LEN);
 }
 
 /**
@@ -1210,7 +1210,7 @@ ostree_checksum_inplace_from_bytes (const guchar *csum,
   static const gchar hexchars[] = "0123456789abcdef";
   guint i, j;
 
-  for (i = 0, j = 0; i < 32; i++, j += 2)
+  for (i = 0, j = 0; i < OSTREE_SHA256_DIGEST_LEN; i++, j += 2)
     {
       guchar byte = csum[i];
       buf[j] = hexchars[byte >> 4];
@@ -1242,7 +1242,7 @@ ostree_checksum_b64_inplace_from_bytes (const guchar *csum,
    * a lot easier to reuse GLib's base64 encoder and postprocess it
    * to replace the '/' with '_'.
    */
-  outlen = g_base64_encode_step (csum, 32, FALSE, tmpbuf, &state, &save);
+  outlen = g_base64_encode_step (csum, OSTREE_SHA256_DIGEST_LEN, FALSE, tmpbuf, &state, &save);
   outlen += g_base64_encode_close (FALSE, tmpbuf+outlen, &state, &save);
   g_assert (outlen == 44);
 
@@ -1299,7 +1299,7 @@ ostree_checksum_bytes_peek (GVariant *bytes)
   gsize n_elts;
   const guchar *ret;
   ret = g_variant_get_fixed_array (bytes, &n_elts, 1);
-  if (G_UNLIKELY (n_elts != 32))
+  if (G_UNLIKELY (n_elts != OSTREE_SHA256_DIGEST_LEN))
     return NULL;
   return ret;
 }
@@ -1434,20 +1434,20 @@ _ostree_get_relative_static_delta_path (const char *from,
                                         const char *to,
                                         const char *target)
 {
-  guint8 csum_to[32];
+  guint8 csum_to[OSTREE_SHA256_DIGEST_LEN];
   char to_b64[44];
-  guint8 csum_to_copy[32];
+  guint8 csum_to_copy[OSTREE_SHA256_DIGEST_LEN];
   GString *ret = g_string_new ("deltas/");
 
   ostree_checksum_inplace_to_bytes (to, csum_to);
   ostree_checksum_b64_inplace_from_bytes (csum_to, to_b64);
   ostree_checksum_b64_inplace_to_bytes (to_b64, csum_to_copy);
 
-  g_assert (memcmp (csum_to, csum_to_copy, 32) == 0);
+  g_assert (memcmp (csum_to, csum_to_copy, OSTREE_SHA256_DIGEST_LEN) == 0);
 
   if (from != NULL)
     {
-      guint8 csum_from[32];
+      guint8 csum_from[OSTREE_SHA256_DIGEST_LEN];
       char from_b64[44];
 
       ostree_checksum_inplace_to_bytes (from, csum_from);

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -50,6 +50,8 @@ G_BEGIN_DECLS
  */
 #define OSTREE_MAX_RECURSION (256)
 
+#define OSTREE_SHA256_DIGEST_LEN (32)
+
 /**
  * OstreeObjectType:
  * @OSTREE_OBJECT_TYPE_FILE: Content; regular file, symbolic link

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -412,12 +412,12 @@ add_size_index_to_metadata (OstreeRepo        *self,
 
       for (i = 0; i < sorted_keys->len; i++)
         {
-          guint8 csum[32];
+          guint8 csum[OSTREE_SHA256_DIGEST_LEN];
           const char *e_checksum = sorted_keys->pdata[i];
           GString *buffer = g_string_new (NULL);
 
           ostree_checksum_inplace_to_bytes (e_checksum, csum);
-          g_string_append_len (buffer, (char*)csum, 32);
+          g_string_append_len (buffer, (char*)csum, sizeof (csum));
 
           e_size = g_hash_table_lookup (self->object_sizes, e_checksum);
           _ostree_write_varuint64 (buffer, e_size->archived);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -123,7 +123,7 @@ typedef struct {
 } FetchStaticDeltaData;
 
 typedef struct {
-  guchar csum[32];
+  guchar csum[OSTREE_SHA256_DIGEST_LEN];
   OstreeObjectType objtype;
   guint recursion_depth;
 } ScanObjectQueueData;
@@ -1150,7 +1150,7 @@ queue_scan_one_metadata_object (OtPullData         *pull_data,
                                 OstreeObjectType    objtype,
                                 guint               recursion_depth)
 {
-  guchar buf[32];
+  guchar buf[OSTREE_SHA256_DIGEST_LEN];
   ostree_checksum_inplace_to_bytes (csum, buf);
   queue_scan_one_metadata_object_c (pull_data, buf, objtype, recursion_depth);
 }
@@ -2067,7 +2067,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           {
             const char *delta;
             GVariant *csum_v = NULL;
-            guchar *csum_data = g_malloc (32);
+            guchar *csum_data = g_malloc (OSTREE_SHA256_DIGEST_LEN);
             g_autoptr(GVariant) ref = g_variant_get_child_value (deltas, i);
 
             g_variant_get_child (ref, 0, "&s", &delta);

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -228,7 +228,7 @@ objtype_checksum_array_new (GPtrArray *objects)
       GVariant *serialized_key = objects->pdata[i];
       OstreeObjectType objtype;
       const char *checksum;
-      guint8 csum[32];
+      guint8 csum[OSTREE_SHA256_DIGEST_LEN];
       guint8 objtype_v;
         
       ostree_object_name_deserialize (serialized_key, &checksum, &objtype);
@@ -678,7 +678,7 @@ process_one_rollsum (OstreeRepo                       *repo,
 
   { gsize mode_offset, xattr_offset, from_csum_offset;
     gboolean reading_payload = TRUE;
-    guchar source_csum[32];
+    guchar source_csum[OSTREE_SHA256_DIGEST_LEN];
     guint i;
 
     write_content_mode_xattrs (repo, current_part, content_finfo, content_xattrs,
@@ -799,7 +799,7 @@ process_one_bsdiff (OstreeRepo                       *repo,
   g_ptr_array_add (current_part->objects, ostree_object_name_serialize (to_checksum, OSTREE_OBJECT_TYPE_FILE));
 
   { gsize mode_offset, xattr_offset;
-    guchar source_csum[32];
+    guchar source_csum[OSTREE_SHA256_DIGEST_LEN];
 
     write_content_mode_xattrs (repo, current_part, content_finfo, content_xattrs,
                                &mode_offset, &xattr_offset);
@@ -1411,7 +1411,7 @@ ostree_repo_static_delta_generate (OstreeRepo                   *self,
                                        cancellable, error))
         goto out;
 
-      checksum_bytes = g_bytes_new (part_checksum, 32);
+      checksum_bytes = g_bytes_new (part_checksum, OSTREE_SHA256_DIGEST_LEN);
       objtype_checksum_array = objtype_checksum_array_new (part_builder->objects);
       delta_part_header = g_variant_new ("(u@aytt@ay)",
                                          OSTREE_DELTAPART_VERSION,

--- a/src/libostree/ostree-repo-static-delta-core.c
+++ b/src/libostree/ostree-repo-static-delta-core.c
@@ -131,7 +131,7 @@ ostree_repo_list_static_delta_names (OstreeRepo                  *self,
                     g_autofree char *buf = g_strconcat (name1, name2, NULL);
                     GString *out = g_string_new ("");
                     char checksum[65];
-                    guchar csum[32];
+                    guchar csum[OSTREE_SHA256_DIGEST_LEN];
                     const char *dash = strchr (buf, '-');
 
                     ostree_checksum_b64_inplace_to_bytes (buf, csum);


### PR DESCRIPTION
And use it internally.  This way it's a bit less magical.