### PR TITLE
build: 'make clean' removes parse-datetime.c

### DIFF
--- a/Makefile-libostree.am
+++ b/Makefile-libostree.am
@@ -182,7 +182,7 @@ pkgconfig_DATA += src/libostree/ostree-1.pc
 
 gpgreadme_DATA = src/libostree/README-gpg
 gpgreadmedir = $(pkgdatadir)/trusted.gpg.d
-EXTRA_DIST += src/libostree/README-gpg src/libostree/bupsplit.h
+EXTRA_DIST += src/libostree/README-gpg src/libostree/bupsplit.h src/libostree/ostree-enumtypes.h.template src/libostree/ostree-enumtypes.c.template src/libostree/ostree-deployment-private.h
 
 install-mkdir-remotes-d-hook:
 	mkdir -p $(DESTDIR)$(sysconfdir)/ostree/remotes.d

--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -89,6 +89,8 @@ ostree_SOURCES += \
 src/ostree/parse-datetime.c: src/ostree/parse-datetime.y Makefile
 	$(AM_V_GEN) $(YACC) $< -o $@
 
+EXTRA_DIST += src/ostree/parse-datetime.y
+CLEANFILES += src/ostree/parse-datetime.c
 
 ostree_bin_shared_cflags = $(AM_CFLAGS) -I$(srcdir)/src/libotutil -I$(srcdir)/src/libostree -I$(srcdir)/src/ostree \
 	$(NULL)


### PR DESCRIPTION
and fix make dist while at it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>