### PR TITLE
pull: Support specifying exact commit to pull

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3784,6 +3784,7 @@ ostree_repo_pull_one_dir (OstreeRepo               *self,
  *   * flags (i): An instance of #OstreeRepoPullFlags
  *   * refs: (as): Array of string refs
  *   * depth: (i): How far in the history to traverse; default is 0, -1 means infinite
+ *   * override-commit-ids: (as): Array of specific commit IDs to fetch for refs
  */
 gboolean
 ostree_repo_pull_with_options (OstreeRepo             *self,

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -34,7 +34,7 @@ static gboolean opt_disable_static_deltas;
 static char* opt_subpath;
 static int opt_depth = 0;
  
- static GOptionEntry options[] = {
+static GOptionEntry options[] = {
    { "commit-metadata-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Fetch only the commit metadata", NULL },
    { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
    { "disable-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_disable_static_deltas, "Do not use static deltas", NULL },
@@ -70,6 +70,7 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
   OstreeRepoPullFlags pullflags = 0;
   GSConsole *console = NULL;
   g_autoptr(GPtrArray) refs_to_fetch = NULL;
+  g_autoptr(GPtrArray) override_commit_ids = NULL;
   glnx_unref_object OstreeAsyncProgress *progress = NULL;
   gulong signal_handler_id = 0;
 
@@ -102,9 +103,36 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
       if (argc > 2)
         {
           int i;
-          refs_to_fetch = g_ptr_array_new ();
+          refs_to_fetch = g_ptr_array_new_with_free_func (g_free);
+
           for (i = 2; i < argc; i++)
-            g_ptr_array_add (refs_to_fetch, argv[i]);
+            {
+              const char *colon = strrchr (argv[i], ':');
+
+              if (colon)
+                {
+                  guint j;
+                  const char *override_commit_id = colon + 1;
+
+                  if (!ostree_validate_checksum_string (override_commit_id, error))
+                    goto out;
+
+                  if (!override_commit_ids)
+                    override_commit_ids = g_ptr_array_new_with_free_func (g_free);
+
+                  /* Backfill */
+                  for (j = 2; j < i; i++)
+                    g_ptr_array_add (override_commit_ids, g_strdup (""));
+
+                  g_ptr_array_add (override_commit_ids, g_strdup (override_commit_id));
+                  g_ptr_array_add (refs_to_fetch, g_strndup (argv[i], colon - argv[i]));
+                }
+              else
+                {
+                  g_ptr_array_add (refs_to_fetch, g_strdup (argv[i]));
+                }
+            }
+
           g_ptr_array_add (refs_to_fetch, NULL);
         }
     }
@@ -146,6 +174,10 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
    
     g_variant_builder_add (&builder, "{s@v}", "disable-static-deltas",
                            g_variant_new_variant (g_variant_new_boolean (opt_disable_static_deltas)));
+
+    if (override_commit_ids)
+      g_variant_builder_add (&builder, "{s@v}", "override-commit-ids",
+                             g_variant_new_variant (g_variant_new_strv ((const char*const*)override_commit_ids->pdata, override_commit_ids->len)));
 
     if (!ostree_repo_pull_with_options (repo, remote, g_variant_builder_end (&builder),
                                         progress, cancellable, error))

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -73,6 +73,21 @@ assert_file_has_content main-meta "HANCOCK"
 echo "ok pull detached metadata"
 
 cd ${test_tmpdir}
+mkdir parentpullrepo
+${CMD_PREFIX} ostree --repo=parentpullrepo init --mode=archive-z2
+${CMD_PREFIX} ostree --repo=parentpullrepo remote add --set=gpg-verify=false origin file://$(pwd)/ostree-srv/gnomerepo
+parent_rev=$(ostree --repo=ostree-srv/gnomerepo rev-parse main^)
+rev=$(ostree --repo=ostree-srv/gnomerepo rev-parse main)
+${CMD_PREFIX} ostree --repo=parentpullrepo pull origin main:${parent_rev}
+${CMD_PREFIX} ostree --repo=parentpullrepo rev-parse origin:main > main.txt
+assert_file_has_content main.txt ${parent_rev}
+${CMD_PREFIX} ostree --repo=parentpullrepo fsck
+${CMD_PREFIX} ostree --repo=parentpullrepo pull origin main
+${CMD_PREFIX} ostree --repo=parentpullrepo rev-parse origin:main > main.txt
+assert_file_has_content main.txt ${rev}
+echo "ok pull specific commit"
+
+cd ${test_tmpdir}
 repo_init
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 ${CMD_PREFIX} ostree --repo=repo fsck


### PR DESCRIPTION
I don't know why we didn't do this a long time ago.  This extends the
pull API to allow grabbing a specific commit, and will set the branch
to it.  There's some support for this in the deploy engine, but there
are a lot of reasons to support it for raw pulls (such as subset
mirroring cases).

In fact I'm thinking we should also have the override-version logic
here too.

NOTE: One thing I debated here is inventing a new syntax on the
command line; you do: `ostree pull remotename branch:commitid`.  We
already use the colon `:` character to separate `remotename:branch`
too.  But a new character would be weird too.

Anyways, I wanted this for some other test cases.  Without this,
writing tests that go between different commits is more awkward as one
must generate the content in one repo, then pull downstream, then
generate more content, then pull again.  But now I can just keep track
of commit IDs and do exactly what I want without synchronizing the
tests.