### PR TITLE
Support Docker-style whiteouts

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -398,7 +398,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
   const char *checksum;
   gboolean is_symlink;
   gboolean can_cache;
-  gboolean need_copy = FALSE;
+  gboolean need_copy = TRUE;
   char loose_path_buf[_OSTREE_LOOSE_PATH_MAX];
   g_autoptr(GInputStream) input = NULL;
   g_autoptr(GVariant) xattrs = NULL;
@@ -434,7 +434,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
     }
   else if (!is_symlink)
     {
-      gboolean did_hardlink;
+      gboolean did_hardlink = FALSE;
       /* Try to do a hardlink first, if it's a regular file.  This also
        * traverses all parent repos.
        */
@@ -503,7 +503,7 @@ checkout_one_file_at (OstreeRepo                        *repo,
   if (can_cache
       && !is_whiteout
       && !is_symlink
-      && !need_copy
+      && need_copy
       && repo->mode == OSTREE_REPO_MODE_ARCHIVE_Z2
       && options->mode == OSTREE_REPO_CHECKOUT_MODE_USER)
     {

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -557,7 +557,8 @@ typedef struct {
   
   guint enable_uncompressed_cache : 1;
   guint disable_fsync : 1;
-  guint reserved : 30;
+  guint process_whiteouts : 1;
+  guint reserved : 29;
 
   const char *subpath;
 

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -387,6 +387,42 @@ assert_file_has_content test2-checkout/baz/cow moo
 assert_has_dir repo2/uncompressed-objects-cache
 echo "ok disable cache checkout"
 
+# Whiteouts
+cd ${test_tmpdir}
+mkdir -p overlay/baz/
+touch overlay/baz/.wh.cow
+touch overlay/.wh.deeper
+touch overlay/anewfile
+mkdir overlay/anewdir/
+touch overlay/anewdir/blah
+$OSTREE --repo=repo commit -b overlay -s 'overlay' --tree=dir=overlay
+rm overlay -rf
+
+for branch in test2 overlay; do
+    $OSTREE --repo=repo checkout --union --whiteouts ${branch} overlay-co
+done
+for f in .wh.deeper baz/cow baz/.wh.cow; do
+    assert_not_has_file overlay-co/${f}
+done
+assert_not_has_dir overlay-co/deeper
+assert_has_file overlay-co/anewdir/blah
+assert_has_file overlay-co/anewfile
+
+echo "ok whiteouts enabled"
+
+# Now double check whiteouts are not processed without --whiteouts 
+rm overlay-co -rf
+for branch in test2 overlay; do
+    $OSTREE --repo=repo checkout --union ${branch} overlay-co
+done
+for f in .wh.deeper baz/cow baz/.wh.cow; do
+    assert_has_file overlay-co/${f}
+done
+assert_not_has_dir overlay-co/deeper
+assert_has_file overlay-co/anewdir/blah
+assert_has_file overlay-co/anewfile
+echo "ok whiteouts disabled"
+
 cd ${test_tmpdir}
 rm -rf test2-checkout
 mkdir -p test2-checkout


### PR DESCRIPTION
This is to enable importing Docker layers as ostree commits, then
checking them out in a union.