### PR TITLE
ostree-sysroot: add debug option to help testing

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -2035,9 +2035,12 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                       cancellable, error))
     goto out;
 
-  if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
-                                              cancellable, error))
-    goto out;
+  if (!(self->debug_flags & OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS))
+    {
+      if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
+                                                  cancellable, error))
+        goto out;
+    }
 
   { ostree_cleanup_sepolicy_fscreatecon gpointer dummy = NULL;
 

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -27,6 +27,13 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+
+  /* Don't flag deployments as immutable. */
+  OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS = 1 << 0
+
+} OstreeSysrootDebugFlags;
+
 struct OstreeSysroot {
   GObject parent;
 
@@ -46,6 +53,7 @@ struct OstreeSysroot {
   /* Only access through ostree_sysroot_get_repo() */
   OstreeRepo *repo;
 
+  OstreeSysrootDebugFlags debug_flags;
 };
 
 #define OSTREE_SYSROOT_LOCKFILE "ostree/lock"

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -153,6 +153,13 @@ ostree_sysroot_class_init (OstreeSysrootClass *klass)
 static void
 ostree_sysroot_init (OstreeSysroot *self)
 {
+  const GDebugKey keys[] = {
+    { "mutable-deployments", OSTREE_SYSROOT_DEBUG_MUTABLE_DEPLOYMENTS },
+  };
+
+  self->debug_flags = g_parse_debug_string (g_getenv("OSTREE_SYSROOT_DEBUG"),
+                                            keys, G_N_ELEMENTS (keys));
+
   self->sysroot_fd = -1;
   self->lock = (GLnxLockFile)GLNX_LOCK_FILE_INIT;
 }

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -22,6 +22,10 @@ test_tmpdir=$(pwd)
 
 export G_DEBUG=fatal-warnings
 
+# Don't flag deployments as immutable so that test harnesses can
+# easily clean up.
+export OSTREE_SYSROOT_DEBUG=mutable-deployments
+
 export TEST_GPG_KEYID_1="472CDAFA"
 export TEST_GPG_KEYID_2="CA950D41"
 export TEST_GPG_KEYID_3="DF444D67"


### PR DESCRIPTION
If ostree is run in a test setup where it operates as root in a tmp
directory, it might cause issues to flag the deployments as immutable.
The test harness might simply be doing an `rm -rf` (effectively the case
for gnome-desktop-testing-runner), which will then fail.

We add a new debug option to the ostree_sysroot object using GLib's
GDebugKey functionality to allow our tests to communicate to ostree that
we don't want immutable deployments.