### PR TITLE
giuseppe/multiple refs

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -61,6 +61,7 @@ testfiles = test-basic \
 	test-xattrs \
 	test-auto-summary \
 	test-prune \
+	test-refs \
 	$(NULL)
 
 if BUILDOPT_FUSE

--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -260,6 +260,7 @@ ostree_repo_write_content_async
 ostree_repo_write_content_finish
 ostree_repo_resolve_rev
 ostree_repo_list_refs
+ostree_repo_list_refs_ext
 ostree_repo_remote_list_refs
 ostree_repo_load_variant
 ostree_repo_load_commit

--- a/man/ostree-refs.xml
+++ b/man/ostree-refs.xml
@@ -57,7 +57,7 @@ Boston, MA 02111-1307, USA.
     <refsect1>
         <title>Description</title>
         <para>
-            Lists all refs available on the host.  If pecified, PREFIX assigns the refspec prefix; default prefix is null, which lists all refs.
+            Lists all refs available on the host.  If specified, PREFIX assigns the refspec prefix; default prefix is null, which lists all refs.
         </para>
     </refsect1>
 

--- a/man/ostree-refs.xml
+++ b/man/ostree-refs.xml
@@ -66,6 +66,13 @@ Boston, MA 02111-1307, USA.
 
         <variablelist>
             <varlistentry>
+                <term><option>--list</option></term>
+
+                <listitem><para>
+                  If a refspec is specified, do not remove it from the output.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><option>--delete</option></term>
 
                 <listitem><para>

--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -181,6 +181,7 @@ global:
         ostree_repo_list_commit_objects_starting_with;
         ostree_repo_list_objects;
         ostree_repo_list_refs;
+        ostree_repo_list_refs_ext;
         ostree_repo_list_static_delta_names;
         ostree_repo_load_commit;
         ostree_repo_load_file;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -342,6 +342,22 @@ gboolean      ostree_repo_list_refs (OstreeRepo       *self,
                                      GCancellable     *cancellable,
                                      GError          **error);
 
+/**
+ * OstreeRepoListRefsExtFlags:
+ * @OSTREE_REPO_LIST_REFS_EXT_NONE: No flags.
+ */
+typedef enum {
+  OSTREE_REPO_LIST_REFS_EXT_NONE = 0,
+} OstreeRepoListRefsExtFlags;
+
+_OSTREE_PUBLIC
+gboolean      ostree_repo_list_refs_ext (OstreeRepo                 *self,
+                                         const char                 *refspec_prefix,
+                                         GHashTable                 **out_all_refs,
+                                         OstreeRepoListRefsExtFlags flags,
+                                         GCancellable               *cancellable,
+                                         GError                     **error);
+
 _OSTREE_PUBLIC
 gboolean ostree_repo_remote_list_refs (OstreeRepo       *self,
                                        const char       *remote_name,

--- a/src/libostree/ostree-sysroot-cleanup.c
+++ b/src/libostree/ostree-sysroot-cleanup.c
@@ -401,7 +401,7 @@ cleanup_ref_prefix (OstreeRepo         *repo,
 
   prefix = g_strdup_printf ("ostree/%d/%d", bootversion, subbootversion);
 
-  if (!ostree_repo_list_refs (repo, prefix, &refs, cancellable, error))
+  if (!ostree_repo_list_refs_ext (repo, prefix, &refs, OSTREE_REPO_LIST_REFS_EXT_NONE, cancellable, error))
     goto out;
 
   if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
@@ -410,8 +410,7 @@ cleanup_ref_prefix (OstreeRepo         *repo,
   g_hash_table_iter_init (&hashiter, refs);
   while (g_hash_table_iter_next (&hashiter, &hashkey, &hashvalue))
     {
-      const char *suffix = hashkey;
-      g_autofree char *ref = g_strconcat (prefix, "/", suffix, NULL);
+      const char *ref = hashkey;
       ostree_repo_transaction_set_refspec (repo, ref, NULL);
     }
 

--- a/src/ostree/ot-builtin-refs.c
+++ b/src/ostree/ot-builtin-refs.c
@@ -33,39 +33,18 @@ static GOptionEntry options[] = {
   { NULL }
 };
 
-gboolean
-ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
+static gboolean do_ref (OstreeRepo *repo, const char *refspec_prefix, GCancellable *cancellable, GError **error)
 {
-  gboolean ret = FALSE;
-  GOptionContext *context;
-  glnx_unref_object OstreeRepo *repo = NULL;
-  const char *refspec_prefix = NULL;
   g_autoptr(GHashTable) refs = NULL;
   GHashTableIter hashiter;
   gpointer hashkey, hashvalue;
-
-  context = g_option_context_new ("[PREFIX] - List refs");
-
-  if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
-    goto out;
-
-  if (argc >= 2)
-    refspec_prefix = argv[1];
-
-  /* Require a prefix when deleting to help avoid accidents. */
-  if (opt_delete && refspec_prefix == NULL)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "PREFIX is required when deleting refs");
-      goto out;
-    }
-
-  if (!ostree_repo_list_refs (repo, refspec_prefix, &refs,
-                              cancellable, error))
-    goto out;
+  gboolean ret = FALSE;
 
   if (!opt_delete)
     {
+      if (!ostree_repo_list_refs (repo, refspec_prefix, &refs, cancellable, error))
+        goto out;
+
       g_hash_table_iter_init (&hashiter, refs);
       while (g_hash_table_iter_next (&hashiter, &hashkey, &hashvalue))
         {
@@ -75,6 +54,10 @@ ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **
     }
   else
     {
+      if (!ostree_repo_list_refs_ext (repo, refspec_prefix, &refs, OSTREE_REPO_LIST_REFS_EXT_NONE,
+                                      cancellable, error))
+        goto out;
+
       g_hash_table_iter_init (&hashiter, refs);
       while (g_hash_table_iter_next (&hashiter, &hashkey, &hashvalue))
         {
@@ -89,6 +72,41 @@ ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **
                                               cancellable, error))
             goto out;
         }
+    }
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+gboolean
+ostree_builtin_refs (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  gboolean ret = FALSE;
+  GOptionContext *context;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  int i;
+
+  context = g_option_context_new ("[PREFIX] - List refs");
+
+  if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    goto out;
+
+  if (argc >= 2)
+    {
+      for (i = 1; i < argc; i++)
+        if (!do_ref (repo, argv[i], cancellable, error))
+          goto out;
+    }
+  else
+    {
+      /* Require a prefix when deleting to help avoid accidents. */
+      if (opt_delete)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "At least one PREFIX is required when deleting refs");
+          goto out;
+        }
+      ret = do_ref (repo, NULL, cancellable, error);
     }
 
   ret = TRUE;

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -239,15 +239,6 @@ fi
 echo "ok prune in archive-z2 deleted everything"
 
 cd ${test_tmpdir}
-$OSTREE commit -b test3 -s "Another commit" --tree=ref=test2
-${CMD_PREFIX} ostree --repo=repo refs > reflist
-assert_file_has_content reflist '^test3$'
-${CMD_PREFIX} ostree --repo=repo refs --delete test3
-${CMD_PREFIX} ostree --repo=repo refs > reflist
-assert_not_file_has_content reflist '^test3$'
-echo "ok reflist --delete"
-
-cd ${test_tmpdir}
 rm -rf test2-checkout
 $OSTREE checkout test2 test2-checkout
 (cd test2-checkout && $OSTREE commit --link-checkout-speedup -b test2 -s "tmp")

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive-z2"
+
+echo '1..1'
+
+cd ${test_tmpdir}
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+
+mkdir -p tree/root
+touch tree/root/a
+
+# Add a few commits
+seq 5 | while read i; do
+    echo a >> tree/root/a
+    ${CMD_PREFIX} ostree --repo=repo commit --branch=test-$i -m test -s test tree
+    ${CMD_PREFIX} ostree --repo=repo commit --branch=foo/test-$i -m test -s test tree
+done
+
+${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount
+assert_file_has_content refscount "^10$"
+
+${CMD_PREFIX} ostree --repo=repo refs foo > refs
+assert_not_file_has_content refs foo
+
+${CMD_PREFIX} ostree --repo=repo refs foo | wc -l > refscount.foo
+assert_file_has_content refscount.foo "^5$"
+
+${CMD_PREFIX} ostree --repo=repo refs --delete 2>/dev/null || true
+${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount.delete1
+assert_file_has_content refscount.delete1 "^10$"
+
+${CMD_PREFIX} ostree refs --delete 2>/dev/null && (echo 1>&2 "refs --delete (without prefix) unexpectedly succeeded!"; exit 1)
+${CMD_PREFIX} ostree --repo=repo refs --delete test-1 test-2
+${CMD_PREFIX} ostree --repo=repo refs | wc -l > refscount.delete2
+assert_file_has_content refscount.delete2 "^8$"
+
+${CMD_PREFIX} ostree refs --repo=repo --delete foo
+${CMD_PREFIX} ostree refs --repo=repo | wc -l > refscount.delete3
+assert_file_has_content refscount.delete3 "^3$"
+assert_not_file_has_content reflist '^test-1$'
+
+echo "ok refs"

--- a/tests/test-refs.sh
+++ b/tests/test-refs.sh
@@ -45,6 +45,9 @@ assert_file_has_content refscount "^10$"
 ${CMD_PREFIX} ostree --repo=repo refs foo > refs
 assert_not_file_has_content refs foo
 
+${CMD_PREFIX} ostree --repo=repo refs --list foo > refs
+assert_file_has_content refs foo
+
 ${CMD_PREFIX} ostree --repo=repo refs foo | wc -l > refscount.foo
 assert_file_has_content refscount.foo "^5$"
 


### PR DESCRIPTION
I am not 100% sure about the change `ostree_repo_list_refs: include the prefix in the refs listing` and what down sides it can have, but that seems to be like the place where the issue described in the its commit message should be fixed.
