### PR TITLE
deploy: Bump the mtime on ostree/deploy after deployments finish

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1855,6 +1855,13 @@ ostree_sysroot_write_deployments (OstreeSysroot     *self,
                                 requires_new_bootversion ? "yes" : "no",
                                 new_deployments->len - self->deployments->len);
 
+  /* Allow other systems to monitor for changes */
+  if (utimensat (self->sysroot_fd, "ostree/deploy", NULL, 0) < 0)
+    {
+      glnx_set_prefix_error_from_errno (error, "%s", "futimens");
+      goto out;
+    }
+
   /* Now reload from disk */
   if (!ostree_sysroot_load (self, cancellable, error))
     {

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -27,11 +27,14 @@ function validate_bootloader() {
      fi)
 }
 
+orig_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 ${CMD_PREFIX} ostree --repo=sysroot/ostree/repo pull-local --remote=testos testos-repo testos/buildmaster/x86_64-runtime
 rev=$(${CMD_PREFIX} ostree --repo=sysroot/ostree/repo rev-parse testos/buildmaster/x86_64-runtime)
 export rev
 # This initial deployment gets kicked off with some kernel arguments 
 ${CMD_PREFIX} ostree admin deploy --karg=root=LABEL=MOO --karg=quiet --os=testos testos:testos/buildmaster/x86_64-runtime
+new_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
+assert_not_streq "${orig_mtime}" "${new_mtime}"
 ${CMD_PREFIX} ostree admin status | tee status.txt
 validate_bootloader
 
@@ -56,7 +59,10 @@ ${CMD_PREFIX} ostree admin status
 
 echo "ok layout"
 
+orig_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
 ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime
+new_mtime=$(stat -c '%.Y' sysroot/ostree/deploy)
+assert_not_streq "${orig_mtime}" "${new_mtime}"
 # Need a new bootversion, sine we now have two deployments
 assert_has_dir sysroot/boot/loader.0
 assert_not_has_dir sysroot/boot/loader.1


### PR DESCRIPTION
This allows other processes (e.g. rpm-ostreed) to monitor for external
changes (e.g. if someone does `ostree admin undeploy`) in a relatively
sane fashion.

Specifically, I'm trying to fix:
projectatomic/rpm-ostree#220