### PR TITLE
lib: Add ostree_sysroot_init_osname() API, bump mtime

### DIFF
--- a/src/libostree/libostree.sym
+++ b/src/libostree/libostree.sym
@@ -316,4 +316,5 @@ LIBOSTREE_2016.4 {
 global:
         ostree_repo_get_dfd;
         ostree_repo_list_refs_ext;
+        ostree_sysroot_init_osname;
 } LIBOSTREE_2016.3;

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1855,12 +1855,8 @@ ostree_sysroot_write_deployments (OstreeSysroot     *self,
                                 requires_new_bootversion ? "yes" : "no",
                                 new_deployments->len - self->deployments->len);
 
-  /* Allow other systems to monitor for changes */
-  if (utimensat (self->sysroot_fd, "ostree/deploy", NULL, 0) < 0)
-    {
-      glnx_set_prefix_error_from_errno (error, "%s", "futimens");
-      goto out;
-    }
+  if (!_ostree_sysroot_bump_mtime (self, error))
+    goto out;
 
   /* Now reload from disk */
   if (!ostree_sysroot_load (self, cancellable, error))

--- a/src/libostree/ostree-sysroot-private.h
+++ b/src/libostree/ostree-sysroot-private.h
@@ -98,6 +98,9 @@ gboolean _ostree_sysroot_query_bootloader (OstreeSysroot     *sysroot,
                                            GCancellable      *cancellable,
                                            GError           **error);
 
+gboolean _ostree_sysroot_bump_mtime (OstreeSysroot *sysroot,
+                                     GError       **error);
+
 typedef enum {
   OSTREE_SYSROOT_CLEANUP_BOOTVERSIONS = 1 << 0,
   OSTREE_SYSROOT_CLEANUP_DEPLOYMENTS  = 1 << 1,

--- a/src/libostree/ostree-sysroot.h
+++ b/src/libostree/ostree-sysroot.h
@@ -98,6 +98,12 @@ _OSTREE_PUBLIC
 void ostree_sysroot_unlock (OstreeSysroot  *self);
 
 _OSTREE_PUBLIC
+gboolean ostree_sysroot_init_osname (OstreeSysroot       *self,
+                                     const char          *osname,
+                                     GCancellable        *cancellable,
+                                     GError             **error);
+
+_OSTREE_PUBLIC
 gboolean ostree_sysroot_cleanup (OstreeSysroot       *self,
                                  GCancellable        *cancellable,
                                  GError             **error);


### PR DESCRIPTION
And change the command line to use it.  rpm-ostree had a copy
of this code, and thus there's a clear reason to have an API.

While we're moving this into API, ensure the mtime on deploy is bumped
after an osname is created, so that daemons like rpm-ostree can notice
changes.  (In reality, creating the directory should do this, but
let's be double sure)