### PR TITLE
tests: Unify some tmpdir code, add ability for C to use libtest.sh

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -121,7 +121,8 @@ libreaddir_rand_la_LDFLAGS = -avoid-version
 
 test_programs = tests/test-varint tests/test-ot-unix-utils tests/test-bsdiff tests/test-mutable-tree \
 	tests/test-keyfile-utils tests/test-ot-opt-utils tests/test-ot-tool-util \
-	tests/test-gpg-verify-result tests/test-checksum tests/test-lzma tests/test-rollsum
+	tests/test-gpg-verify-result tests/test-checksum tests/test-lzma tests/test-rollsum \
+	tests/test-basic-c
 
 # An interactive tool
 noinst_PROGRAMS += tests/test-rollsum-cli
@@ -130,8 +131,16 @@ if USE_LIBARCHIVE
 test_programs += tests/test-libarchive-import
 endif
 
-TESTS_CFLAGS = $(ostree_bin_shared_cflags) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -I$(srcdir)/libglnx
-TESTS_LDADD = $(ostree_bin_shared_ldadd) $(OT_INTERNAL_GIO_UNIX_LIBS)
+common_tests_cflags = $(ostree_bin_shared_cflags) $(OT_INTERNAL_GIO_UNIX_CFLAGS) -I$(srcdir)/libglnx
+common_tests_ldadd = $(ostree_bin_shared_ldadd) $(OT_INTERNAL_GIO_UNIX_LIBS)
+
+noinst_LTLIBRARIES += libostreetest.la
+libostreetest_la_SOURCES = tests/libostreetest.c
+libostreetest_la_CFLAGS = $(common_tests_cflags) -I $(srcdir)/tests
+libostreetest_la_LIBADD = $(common_tests_ldadd)
+
+TESTS_CFLAGS = $(common_tests_cflags)
+TESTS_LDADD = $(common_tests_ldadd) libostreetest.la
 
 tests_test_rollsum_cli_SOURCES = src/libostree/ostree-rollsum.c tests/test-rollsum-cli.c
 tests_test_rollsum_cli_CFLAGS = $(TESTS_CFLAGS) $(OT_DEP_ZLIB_CFLAGS)
@@ -143,6 +152,9 @@ tests_test_rollsum_LDADD = libbupsplit.la $(TESTS_LDADD) $(OT_DEP_ZLIB_LIBS)
 
 tests_test_mutable_tree_CFLAGS = $(TESTS_CFLAGS)
 tests_test_mutable_tree_LDADD = $(TESTS_LDADD)
+
+tests_test_basic_c_CFLAGS = $(TESTS_CFLAGS)
+tests_test_basic_c_LDADD = $(TESTS_LDADD)
 
 tests_test_ot_unix_utils_CFLAGS = $(TESTS_CFLAGS)
 tests_test_ot_unix_utils_LDADD = $(TESTS_LDADD)

--- a/buildutil/tap-test
+++ b/buildutil/tap-test
@@ -1,12 +1,22 @@
 #! /bin/bash
-
-# run a GTest in tap mode. The test binary is passed as $1
+#
+# Run a test in tap mode, ensuring we have a temporary directory.  We
+# always use /var/tmp becuase we might want to use user xattrs, which
+# aren't available on tmpfs.
+#
+# The test binary is passed as $1
 
 srcd=$(cd $(dirname $1) && pwd)
 bn=$(basename $1)
-tempdir=$(mktemp -d)
+tempdir=$(mktemp -d /var/tmp/tap-test.XXXXXX)
+touch ${tempdir}/.testtmp
 function cleanup () {
-    rm "${tempdir}" -rf
+    if test -n "${TEST_SKIP_CLEANUP:-}"; then
+	echo "Skipping cleanup of ${test_tmpdir}"
+    else if test -f ${tempdir}/.test; then
+	rm "${tempdir}" -rf
+    fi
+    fi
 }
 trap cleanup EXIT
 cd ${tempdir}

--- a/tests/libostreetest.c
+++ b/tests/libostreetest.c
@@ -1,0 +1,82 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <string.h>
+
+#include "libglnx.h"
+#include "libostreetest.h"
+
+/* This function hovers in a quantum superposition of horrifying and
+ * beautiful.  Future generations may interpret it as modern art.
+ */
+static gboolean
+run_libtest (const char *cmd, GError **error)
+{
+  gboolean ret = FALSE;
+  const char *builddir = g_getenv ("G_TEST_BUILDDIR");
+  int estatus;
+  g_autoptr(GPtrArray) argv = g_ptr_array_new ();
+  g_autoptr(GString) cmdstr = g_string_new ("");
+
+  g_ptr_array_add (argv, "bash");
+  g_ptr_array_add (argv, "-c");
+
+  g_string_append (cmdstr, ". ");
+  g_string_append (cmdstr, builddir);
+  g_string_append (cmdstr, "/tests/libtest.sh; ");
+  g_string_append (cmdstr, cmd);
+
+  g_ptr_array_add (argv, cmdstr->str);
+  g_ptr_array_add (argv, NULL);
+
+  if (!g_spawn_sync (NULL, (char**)argv->pdata, NULL, G_SPAWN_SEARCH_PATH,
+                     NULL, NULL, NULL, NULL, &estatus, error))
+    goto out;
+
+  if (!g_spawn_check_exit_status (estatus, error))
+    goto out;
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+gboolean
+ot_test_setup_repo (OtTest *self,
+                    GCancellable *cancellable,
+                    GError **error)
+{
+  gboolean ret = FALSE;
+  g_autoptr(GFile) repo_path = g_file_new_for_path ("repo");
+
+  if (!run_libtest ("setup_test_repository", error))
+    goto out;
+
+  self->repo = ostree_repo_new (repo_path);
+
+  if (!ostree_repo_open (self->repo, cancellable, error))
+    goto out;
+
+  ret = TRUE;
+ out:
+  return ret;
+}

--- a/tests/libostreetest.h
+++ b/tests/libostreetest.h
@@ -1,0 +1,39 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2016 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Colin Walters <walters@verbum.org>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+typedef struct {
+  OstreeRepo *repo;
+  GSubprocess *shell;
+} OtTest;
+
+gboolean ot_test_setup_repo (OtTest *self,
+                             GCancellable *cancellable,
+                             GError **error);
+
+G_END_DECLS

--- a/tests/test-basic-c.c
+++ b/tests/test-basic-c.c
@@ -1,0 +1,54 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+#include "libglnx.h"
+#include "libostreetest.h"
+
+static void
+test_repo_is_not_system (gconstpointer data)
+{
+  OtTest *self = (void*)data;
+  g_assert (!ostree_repo_is_system (self->repo));
+}
+
+int main (int argc, char **argv)
+{
+  g_autoptr(GError) error = NULL;
+  OtTest selfd = {NULL,};
+
+  g_test_init (&argc, &argv, NULL);
+
+  if (!ot_test_setup_repo (&selfd, NULL, &error))
+    goto out;
+  
+  g_test_add_data_func ("/repo-not-system", &selfd, test_repo_is_not_system);
+
+  return g_test_run();
+ out:
+  if (error)
+    g_error ("%s", error->message);
+  return 1;
+}


### PR DESCRIPTION
I want to be able to easily test the C API on actual data in an OSTree
repo.  The shell `libtest.sh` has code to generate it.  Bridge the two
worlds by introducing a little `libostreetest` library which has a C
API which spawns a shell that runs things in `libtest.sh`.

Yes, this is about as beautiful as it sounds, which is to say, it's
not.  But it works!

Note while we were here, I realized we were actually now creating
*two* tmpdirs per test in `make check` because the tap driver was
already doing that.  Unify it so we know the C code can rely on it.