### PR TITLE
build: Don't install test data without --enable-installed-tests

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -92,6 +92,9 @@ installed_test_data = tests/archive-test.sh \
 
 test_extra_scripts = tests/syslinux-entries-crosscheck.py
 
+# We can't use nobase_ as we need to strip off the tests/, can't
+# use plain installed_ as we do need the gpghome/ prefix.
+if ENABLE_INSTALLED_TESTS
 gpginsttestdir = $(installed_testdir)/gpghome
 gpginsttest_DATA = tests/gpghome/secring.gpg \
 	tests/gpghome/pubring.gpg \
@@ -105,6 +108,7 @@ gpginsttest_trusted_DATA = tests/gpghome/trusted/pubring.gpg
 gpgvinsttestdir = $(installed_testdir)/gpg-verify-data
 gpgvinsttest_DATA = $(addprefix tests/gpg-verify-data/, \
 	gpg.conf lgpl2 lgpl2.sig pubring.gpg secring.gpg trustdb.gpg)
+endif
 
 if BUILDOPT_GJS
 installed_test_scripts = tests/test-core.js \
@@ -209,9 +213,11 @@ EXTRA_DIST += \
 # Unfortunately the glib test data APIs don't actually handle
 # non-recursive Automake, so we change our code to canonically look
 # for tests/ which is just a symlink when installed.
+if ENABLE_INSTALLED_TESTS
 install-test-data-file-path-hack:
 	if test -L $(DESTDIR)$(installed_testdir)/tests; then \
 	  rm $(DESTDIR)$(installed_testdir)/tests; \
 	fi
 	ln -s . $(DESTDIR)$(installed_testdir)/tests
 INSTALL_DATA_HOOKS += install-test-data-file-path-hack
+endif


### PR DESCRIPTION
Otherwise $(installed_testdir) is empty so we try to put content in
`/`, which I noticed when trying to build an RPM (it works works fine
`sudo make install`).