### PR TITLE
repo: Fix the skip-summary-if-summary.sig-is-same cache

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1803,6 +1803,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
 
   if (*out_summary)
     from_cache = TRUE;
+  else
     {
       if (!_ostree_preload_metadata_file (self,
                                           fetcher,


### PR DESCRIPTION
This code was always downloading the summary even for a cache hit due
to a missing else.