### PR TITLE
Upstreaming debian patches

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -179,8 +179,8 @@ tests_test_checksum_CFLAGS = $(TESTS_CFLAGS) $(libglnx_cflags)
 tests_test_checksum_LDADD = $(TESTS_LDADD)
 
 tests_test_libarchive_import_SOURCES = tests/test-libarchive-import.c
-tests_test_libarchive_import_CFLAGS = $(TESTS_CFLAGS) $(libglnx_cflags)
-tests_test_libarchive_import_LDADD = $(TESTS_LDADD)
+tests_test_libarchive_import_CFLAGS = $(TESTS_CFLAGS) $(libglnx_cflags) $(OT_DEP_LIBARCHIVE_CFLAGS)
+tests_test_libarchive_import_LDADD = $(TESTS_LDADD) $(OT_DEP_LIBARCHIVE_LIBS)
 
 tests_test_keyfile_utils_CFLAGS = $(TESTS_CFLAGS)
 tests_test_keyfile_utils_LDADD = $(TESTS_LDADD)

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -1,4 +1,4 @@
-#
+#!/bin/sh
 # Copyright (C) 2011,2014 Colin Walters <walters@verbum.org>
 #
 # This library is free software; you can redistribute it and/or

--- a/tests/test-libarchive-import.c
+++ b/tests/test-libarchive-import.c
@@ -193,6 +193,15 @@ test_libarchive_ignore_device_file (gconstpointer data)
   glnx_unref_object GFile *root = NULL;
   g_autofree char *commit_checksum = NULL;
 
+  if (setxattr (td->tmpd, "user.test-xattr-support", "yes", 4, 0) != 0)
+    {
+      int saved_errno = errno;
+      g_autofree gchar *message = g_strdup_printf ("unable to setxattr on \"%s\": %s", td->tmpd, g_strerror (saved_errno));
+
+      g_test_skip (message);
+      goto out;
+    }
+
   g_assert_cmpint (0, ==, lseek (td->fd, 0, SEEK_SET));
   g_assert_cmpint (0, ==, archive_read_support_format_all (a));
   g_assert_cmpint (0, ==, archive_read_support_filter_all (a));


### PR DESCRIPTION
Alex pointed me at https://anonscm.debian.org/git/collab-maint/ostree.git/tree/debian/patches - they're all fine, and should be upstream.