### PR TITLE
admin-switch: Add missing reboot argument

### DIFF
--- a/src/ostree/ot-admin-builtin-switch.c
+++ b/src/ostree/ot-admin-builtin-switch.c
@@ -34,6 +34,7 @@ static gboolean opt_reboot;
 static char *opt_osname;
 
 static GOptionEntry options[] = {
+  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Reboot after switching trees", NULL },
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Use a different operating system root than the current one", "OSNAME" },
   { NULL }
 };


### PR DESCRIPTION
Spotted by jlebon in https://github.com/GNOME/ostree/pull/211